### PR TITLE
feat: mem system

### DIFF
--- a/app.mk
+++ b/app.mk
@@ -15,6 +15,7 @@ LDFLAGS = -static -L$(SDK_LIB_DIR) -L$(MUSL_LIB_DIR) -lpenglai-enclave-eapp -lc
 CFLAGS += -I$(SDK_INCLUDE_DIR)
 
 APP_C_OBJS = $(patsubst %.c,%.o, $(APP_C_SRCS))
+APP_S_OBJS = $(patsubst %.S,%.o, $(APP_S_SRCS))
 APP_A_OBJS = $(patsubst %.s,%.o, $(APP_A_SRCS))
 APP_LDS ?= $(PENGLAI_SDK)/app.lds
 
@@ -26,7 +27,11 @@ $(APP_C_OBJS): %.o: %.c
 	echo $(PENGLAI_SDK)
 	$(CC) $(CFLAGS) -c $<
 
-$(APP_BIN): % : $(APP_C_OBJS) $(APP_A_OBJS) $(SDK_APP_LIB) $(MUSL_LIBC) $(GCC_LIB)
+$(APP_S_OBJS): %.o: %.S
+	echo $(PENGLAI_SDK)
+	$(CC) $(CFLAGS) -c $<
+
+$(APP_BIN): % : $(APP_C_OBJS) $(APP_A_OBJS) $(APP_S_OBJS) $(SDK_APP_LIB) $(MUSL_LIBC) $(GCC_LIB)
 	$(LINK) $(LDFLAGS) -o $@ $^ -T $(APP_LDS)
 	chmod -x $@
 

--- a/demo/liteos_m/Makefile
+++ b/demo/liteos_m/Makefile
@@ -1,4 +1,5 @@
 APP = liteos_m
-APP_C_SRCS = main.c los_init.c
+APP_S_SRCS = los_dispatch.S
+APP_C_SRCS = main.c los_init.c los_memory.c los_task.c los_context.c
 EXTRA_CLEAN = $(APP).dump
 include $(PENGLAI_SDK)/app.mk

--- a/demo/liteos_m/los_context.c
+++ b/demo/liteos_m/los_context.c
@@ -1,0 +1,15 @@
+#include "los_context.h"
+
+/* ****************************************************************************
+ Function    : HalSysExit
+ Description : Task exit function
+ Input       : None
+ Output      : None
+ Return      : None
+ **************************************************************************** */
+LITE_OS_SEC_TEXT_MINOR VOID HalSysExit(VOID)
+{
+    LOS_IntLock();
+    while (1) {
+    }
+}

--- a/demo/liteos_m/los_init.c
+++ b/demo/liteos_m/los_init.c
@@ -1,5 +1,33 @@
 #include "los_compiler.h"
+#include "los_task.h"
+#include "los_memory.h"
+#include "los_context.h"
+#include "target_config.h"
 #include "print.h"
+
+/*****************************************************************************
+ Function    : OsRegister
+ Description : Configuring the maximum number of tasks
+ Input       : None
+ Output      : None
+ Return      : None
+ *****************************************************************************/
+LITE_OS_SEC_TEXT_INIT static VOID OsRegister(VOID)
+{
+    // TODO(zhidong): remove comment after los_task.c is ported
+    // g_taskMaxNum = LOSCFG_BASE_CORE_TSK_LIMIT + 1; /* Reserved 1 for IDLE */
+
+    return;
+}
+
+LITE_OS_SEC_TEXT_INIT VOID LOS_Panic(const CHAR *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    PRINT_ERR(fmt, ap);
+    va_end(ap);
+    HalSysExit();
+}
 
 /*****************************************************************************
  Function    : LOS_KernelInit
@@ -12,11 +40,6 @@ UINT32 LOS_KernelInit(VOID)
 {
     UINT32 ret;
     PRINTK("entering kernel init...\n");
-    return LOS_OK;
-#if 0
-#if (LOSCFG_BACKTRACE_TYPE != 0)
-    OSBackTraceInit();
-#endif
 
     OsRegister();
     ret = OsMemSystemInit();
@@ -25,96 +48,23 @@ UINT32 LOS_KernelInit(VOID)
         return ret;
     }
 
-    HalArchInit();
+    char * ptr = LOS_MemAlloc(m_aucSysMem0, 100);
+    PRINTK("allocated mem is %p\n", ptr);
+    *ptr = 0;
+    LOS_MemFree(m_aucSysMem0, ptr);
 
-    ret = OsTaskInit();
-    if (ret != LOS_OK) {
-        PRINT_ERR("OsTaskInit error\n");
-        return ret;
-    }
+    // HalArchInit();
 
-#if (LOSCFG_BASE_CORE_TSK_MONITOR == 1)
-    OsTaskMonInit();
-#endif
+    // ret = OsTaskInit();
+    // if (ret != LOS_OK) {
+    //     PRINT_ERR("OsTaskInit error\n");
+    //     return ret;
+    // }
 
-#if (LOSCFG_BASE_CORE_CPUP == 1)
-    ret = OsCpupInit();
-    if (ret != LOS_OK) {
-        PRINT_ERR("OsCpupInit error\n");
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_BASE_IPC_SEM == 1)
-    ret = OsSemInit();
-    if (ret != LOS_OK) {
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_BASE_IPC_MUX == 1)
-    ret = OsMuxInit();
-    if (ret != LOS_OK) {
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_BASE_IPC_QUEUE == 1)
-    ret = OsQueueInit();
-    if (ret != LOS_OK) {
-        PRINT_ERR("OsQueueInit error\n");
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_BASE_CORE_SWTMR == 1)
-    ret = OsSwtmrInit();
-    if (ret != LOS_OK) {
-        PRINT_ERR("OsSwtmrInit error\n");
-        return ret;
-    }
-#endif
-
-    ret = OsIdleTaskCreate();
-    if (ret != LOS_OK) {
-        return ret;
-    }
-
-#if (LOSCFG_KERNEL_TRACE == 1)
-    ret = OsTraceInit(LOSCFG_TRACE_BUFFER_SIZE);
-    if (ret != LOS_OK) {
-        PRINT_ERR("OsTraceInit error\n");
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_KERNEL_PM == 1)
-    ret = OsPmInit();
-    if (ret != LOS_OK) {
-        PRINT_ERR("Pm init failed!\n");
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_TEST == 1)
-    ret = los_TestInit();
-    if (ret != LOS_OK) {
-        PRINT_ERR("los_TestInit error\n");
-        return ret;
-    }
-#endif
-
-#if (LOSCFG_PLATFORM_EXC == 1)
-    OsExcMsgDumpInit();
-#endif
-
-#if (LOSCFG_DYNLINK == 1)
-    ret = LOS_DynlinkInit();
-    if (ret != LOS_OK) {
-        return ret;
-    }
-#endif
+    // ret = OsIdleTaskCreate();
+    // if (ret != LOS_OK) {
+    //     return ret;
+    // }
 
     return LOS_OK;
-#endif
 }

--- a/demo/liteos_m/los_init.c
+++ b/demo/liteos_m/los_init.c
@@ -48,11 +48,6 @@ UINT32 LOS_KernelInit(VOID)
         return ret;
     }
 
-    char * ptr = LOS_MemAlloc(m_aucSysMem0, 100);
-    PRINTK("allocated mem is %p\n", ptr);
-    *ptr = 0;
-    LOS_MemFree(m_aucSysMem0, ptr);
-
     // HalArchInit();
 
     // ret = OsTaskInit();

--- a/demo/liteos_m/los_memory.c
+++ b/demo/liteos_m/los_memory.c
@@ -1,0 +1,2089 @@
+#include "los_memory.h"
+#include "los_interrupt.h"
+
+STATIC UINT8 g_memStart[LOSCFG_SYS_HEAP_SIZE];
+
+/* Used to cut non-essential functions. */
+#define OS_MEM_EXPAND_ENABLE    0
+
+UINT8 *m_aucSysMem0 = NULL;
+
+#if (LOSCFG_SYS_EXTERNAL_HEAP == 0)
+STATIC UINT8 g_memStart[LOSCFG_SYS_HEAP_SIZE];
+#endif
+
+#if (LOSCFG_MEM_MUL_POOL == 1)
+VOID *g_poolHead = NULL;
+#endif
+
+/* The following is the macro definition and interface implementation related to the TLSF. */
+
+/* Supposing a Second Level Index: SLI = 3. */
+#define OS_MEM_SLI                      3
+/* Giving 1 free list for each small bucket: 4, 8, 12, up to 124. */
+#define OS_MEM_SMALL_BUCKET_COUNT       31
+#define OS_MEM_SMALL_BUCKET_MAX_SIZE    128
+/* Giving 2^OS_MEM_SLI free lists for each large bucket. */
+#define OS_MEM_LARGE_BUCKET_COUNT       24
+/* OS_MEM_SMALL_BUCKET_MAX_SIZE to the power of 2 is 7. */
+#define OS_MEM_LARGE_START_BUCKET       7
+
+/* The count of free list. */
+#define OS_MEM_FREE_LIST_COUNT  (OS_MEM_SMALL_BUCKET_COUNT + (OS_MEM_LARGE_BUCKET_COUNT << OS_MEM_SLI))
+/* The bitmap is used to indicate whether the free list is empty, 1: not empty, 0: empty. */
+#define OS_MEM_BITMAP_WORDS     ((OS_MEM_FREE_LIST_COUNT >> 5) + 1)
+
+#define OS_MEM_BITMAP_MASK 0x1FU
+
+/* Used to find the first bit of 1 in bitmap. */
+STATIC INLINE UINT16 OsMemFFS(UINT32 bitmap)
+{
+    bitmap &= ~bitmap + 1;
+    return (OS_MEM_BITMAP_MASK - CLZ(bitmap));
+}
+
+/* Used to find the last bit of 1 in bitmap. */
+STATIC INLINE UINT16 OsMemFLS(UINT32 bitmap)
+{
+    return (OS_MEM_BITMAP_MASK - CLZ(bitmap));
+}
+
+STATIC INLINE UINT32 OsMemLog2(UINT32 size)
+{
+    return (size > 0) ? OsMemFLS(size) : 0;
+}
+
+/* Get the first level: f = log2(size). */
+STATIC INLINE UINT32 OsMemFlGet(UINT32 size)
+{
+    if (size < OS_MEM_SMALL_BUCKET_MAX_SIZE) {
+        return ((size >> 2) - 1); /* 2: The small bucket setup is 4. */
+    }
+    return (OsMemLog2(size) - OS_MEM_LARGE_START_BUCKET + OS_MEM_SMALL_BUCKET_COUNT);
+}
+
+/* Get the second level: s = (size - 2^f) * 2^SLI / 2^f. */
+STATIC INLINE UINT32 OsMemSlGet(UINT32 size, UINT32 fl)
+{
+    if ((fl < OS_MEM_SMALL_BUCKET_COUNT) || (size < OS_MEM_SMALL_BUCKET_MAX_SIZE)) {
+        PRINT_ERR("fl or size is too small, fl = %u, size = %u\n", fl, size);
+        return 0;
+    }
+
+    UINT32 sl = (size << OS_MEM_SLI) >> (fl - OS_MEM_SMALL_BUCKET_COUNT + OS_MEM_LARGE_START_BUCKET);
+    return (sl - (1 << OS_MEM_SLI));
+}
+
+/* The following is the memory algorithm related macro definition and interface implementation. */
+#if (LOSCFG_TASK_MEM_USED != 1 && LOSCFG_MEM_FREE_BY_TASKID == 1 && (LOSCFG_BASE_CORE_TSK_LIMIT + 1) > 64)
+#error "When enter here, LOSCFG_BASE_CORE_TSK_LIMIT larger than 63 is not support"
+#endif
+
+struct OsMemNodeHead {
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+    UINT32 magic;
+#endif
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+    UINTPTR linkReg[LOSCFG_MEM_RECORD_LR_CNT];
+#endif
+    union {
+        struct OsMemNodeHead *prev; /* The prev is used for current node points to the previous node */
+        struct OsMemNodeHead *next; /* The next is used for sentinel node points to the expand node */
+    } ptr;
+#if (LOSCFG_TASK_MEM_USED == 1)
+    UINT32 taskID;
+    UINT32 sizeAndFlag;
+#elif (LOSCFG_MEM_FREE_BY_TASKID == 1)
+    UINT32 taskID : 6;
+    UINT32 sizeAndFlag : 26;
+#else
+    UINT32 sizeAndFlag;
+#endif
+};
+
+struct OsMemUsedNodeHead {
+    struct OsMemNodeHead header;
+};
+
+struct OsMemFreeNodeHead {
+    struct OsMemNodeHead header;
+    struct OsMemFreeNodeHead *prev;
+    struct OsMemFreeNodeHead *next;
+};
+
+struct OsMemPoolInfo {
+    VOID *pool;
+    UINT32 totalSize;
+    UINT32 attr;
+#if (LOSCFG_MEM_WATERLINE == 1)
+    UINT32 waterLine;   /* Maximum usage size in a memory pool */
+    UINT32 curUsedSize; /* Current usage size in a memory pool */
+#endif
+#if (LOSCFG_MEM_MUL_REGIONS == 1)
+    UINT32 totalGapSize;
+#endif
+};
+
+struct OsMemPoolHead {
+    struct OsMemPoolInfo info;
+    UINT32 freeListBitmap[OS_MEM_BITMAP_WORDS];
+    struct OsMemFreeNodeHead *freeList[OS_MEM_FREE_LIST_COUNT];
+#if (LOSCFG_MEM_MUL_POOL == 1)
+    VOID *nextPool;
+#endif
+};
+
+/* The memory pool support expand. */
+#define OS_MEM_POOL_EXPAND_ENABLE   0x01
+/* The memory pool support no lock. */
+#define OS_MEM_POOL_UNLOCK_ENABLE   0x02
+
+#define MEM_LOCK(pool, state)       do {                    \
+    if (!((pool)->info.attr & OS_MEM_POOL_UNLOCK_ENABLE)) { \
+        (state) = LOS_IntLock();                            \
+    }                                                       \
+} while (0);
+#define MEM_UNLOCK(pool, state)     do {                    \
+    if (!((pool)->info.attr & OS_MEM_POOL_UNLOCK_ENABLE)) { \
+        LOS_IntRestore(state);                              \
+    }                                                       \
+} while (0);
+
+#define OS_MEM_NODE_MAGIC          0xABCDDCBA
+#if (LOSCFG_TASK_MEM_USED != 1 && LOSCFG_MEM_FREE_BY_TASKID == 1)
+#define OS_MEM_NODE_USED_FLAG      (1U << 25)
+#define OS_MEM_NODE_ALIGNED_FLAG   (1U << 24)
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+#define OS_MEM_NODE_LEAK_FLAG      (1U << 23)
+#else
+#define OS_MEM_NODE_LEAK_FLAG      0
+#endif
+#if (OS_MEM_EXPAND_ENABLE == 1)
+#define OS_MEM_NODE_LAST_FLAG      (1U << 22)  /* Sentinel Node */
+#else
+#define OS_MEM_NODE_LAST_FLAG      0
+#endif
+#else
+#define OS_MEM_NODE_USED_FLAG      (1U << 31)
+#define OS_MEM_NODE_ALIGNED_FLAG   (1U << 30)
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+#define OS_MEM_NODE_LEAK_FLAG      (1U << 29)
+#else
+#define OS_MEM_NODE_LEAK_FLAG      0
+#endif
+#if (OS_MEM_EXPAND_ENABLE == 1)
+#define OS_MEM_NODE_LAST_FLAG      (1U << 28)  /* Sentinel Node */
+#else
+#define OS_MEM_NODE_LAST_FLAG      0
+#endif
+#endif
+
+#define OS_MEM_NODE_ALIGNED_AND_USED_FLAG \
+    (OS_MEM_NODE_USED_FLAG | OS_MEM_NODE_ALIGNED_FLAG | OS_MEM_NODE_LEAK_FLAG | OS_MEM_NODE_LAST_FLAG)
+
+#define OS_MEM_NODE_GET_ALIGNED_FLAG(sizeAndFlag) \
+            ((sizeAndFlag) & OS_MEM_NODE_ALIGNED_FLAG)
+#define OS_MEM_NODE_SET_ALIGNED_FLAG(sizeAndFlag) \
+            (sizeAndFlag) = ((sizeAndFlag) | OS_MEM_NODE_ALIGNED_FLAG)
+#define OS_MEM_NODE_GET_USED_FLAG(sizeAndFlag) \
+            ((sizeAndFlag) & OS_MEM_NODE_USED_FLAG)
+#define OS_MEM_NODE_SET_USED_FLAG(sizeAndFlag) \
+            (sizeAndFlag) = ((sizeAndFlag) | OS_MEM_NODE_USED_FLAG)
+#define OS_MEM_NODE_GET_SIZE(sizeAndFlag) \
+            ((sizeAndFlag) & ~OS_MEM_NODE_ALIGNED_AND_USED_FLAG)
+
+#define OS_MEM_GAPSIZE_USED_FLAG      0x80000000U
+#define OS_MEM_GAPSIZE_ALIGNED_FLAG   0x40000000U
+#define OS_MEM_GET_ALIGNED_GAPSIZE(gapsize) \
+            ((gapsize) & ~OS_MEM_GAPSIZE_ALIGNED_FLAG)
+#define OS_MEM_GET_GAPSIZE_ALIGNED_FLAG(gapsize) \
+                ((gapsize) & OS_MEM_GAPSIZE_ALIGNED_FLAG)
+#define OS_MEM_SET_GAPSIZE_ALIGNED_FLAG(gapsize) \
+                (gapsize) = ((gapsize) | OS_MEM_GAPSIZE_ALIGNED_FLAG)
+#define OS_MEM_GET_GAPSIZE_USED_FLAG(gapsize) \
+                ((gapsize) & OS_MEM_GAPSIZE_USED_FLAG)
+#define OS_MEM_GAPSIZE_CHECK(gapsize) \
+                (OS_MEM_GET_GAPSIZE_ALIGNED_FLAG(gapsize) && \
+                 OS_MEM_GET_GAPSIZE_USED_FLAG(gapsize))
+
+#define OS_MEM_NODE_SET_LAST_FLAG(sizeAndFlag) \
+            (sizeAndFlag) = ((sizeAndFlag) | OS_MEM_NODE_LAST_FLAG)
+#define OS_MEM_NODE_GET_LAST_FLAG(sizeAndFlag) \
+            ((sizeAndFlag) & OS_MEM_NODE_LAST_FLAG)
+#define OS_MEM_NODE_GET_LEAK_FLAG(sizeAndFlag) \
+            ((sizeAndFlag) & OS_MEM_NODE_LEAK_FLAG)
+#define OS_MEM_NODE_SET_LEAK_FLAG(sizeAndFlag) \
+            (sizeAndFlag) = ((sizeAndFlag) | OS_MEM_NODE_LEAK_FLAG)
+
+#define OS_MEM_ALIGN_SIZE           sizeof(UINTPTR)
+#define OS_MEM_IS_POW_TWO(value)    ((((UINTPTR)(value)) & ((UINTPTR)(value) - 1)) == 0)
+#define OS_MEM_ALIGN(p, alignSize)  (((UINTPTR)(p) + (alignSize) - 1) & ~((UINTPTR)((alignSize) - 1)))
+#define OS_MEM_IS_ALIGNED(a, b)     (!(((UINTPTR)(a)) & (((UINTPTR)(b)) - 1)))
+#define OS_MEM_NODE_HEAD_SIZE       sizeof(struct OsMemUsedNodeHead)
+#define OS_MEM_MIN_POOL_SIZE        (OS_MEM_NODE_HEAD_SIZE + sizeof(struct OsMemPoolHead))
+#define OS_MEM_MIN_LEFT_SIZE        sizeof(struct OsMemFreeNodeHead)
+#define OS_MEM_MIN_ALLOC_SIZE       8
+#define OS_MEM_NEXT_NODE(node) \
+    ((struct OsMemNodeHead *)(VOID *)((UINT8 *)(node) + OS_MEM_NODE_GET_SIZE((node)->sizeAndFlag)))
+#define OS_MEM_FIRST_NODE(pool) \
+    (struct OsMemNodeHead *)((UINT8 *)(pool) + sizeof(struct OsMemPoolHead))
+#define OS_MEM_END_NODE(pool, size) \
+    (struct OsMemNodeHead *)((UINT8 *)(pool) + (size) - OS_MEM_NODE_HEAD_SIZE)
+#define OS_MEM_MIDDLE_ADDR_OPEN_END(startAddr, middleAddr, endAddr) \
+    (((UINT8 *)(startAddr) <= (UINT8 *)(middleAddr)) && ((UINT8 *)(middleAddr) < (UINT8 *)(endAddr)))
+#define OS_MEM_MIDDLE_ADDR(startAddr, middleAddr, endAddr) \
+    (((UINT8 *)(startAddr) <= (UINT8 *)(middleAddr)) && ((UINT8 *)(middleAddr) <= (UINT8 *)(endAddr)))
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+STATIC INLINE UINT32 OsMemAllocCheck(struct OsMemPoolHead *pool, UINT32 intSave);
+#define OS_MEM_SET_MAGIC(node)      ((node)->magic = OS_MEM_NODE_MAGIC)
+#define OS_MEM_MAGIC_VALID(node)    ((node)->magic == OS_MEM_NODE_MAGIC)
+#else
+#define OS_MEM_SET_MAGIC(node)
+#define OS_MEM_MAGIC_VALID(node)    TRUE
+#endif
+
+#if (LOSCFG_MEM_MUL_REGIONS == 1)
+/**
+ *  When LOSCFG_MEM_MUL_REGIONS is enabled to support multiple non-continuous memory regions,
+ *  the gap between two memory regions is marked as a used OsMemNodeHead node. The gap node
+ *  couldn't be freed, and would also be skipped in some DFX functions. The 'ptr.prev' pointer
+ *  of this node is set to OS_MEM_GAP_NODE_MAGIC to identify that this is a gap node.
+*/
+#define OS_MEM_GAP_NODE_MAGIC       0xDCBAABCD
+#define OS_MEM_MARK_GAP_NODE(node)  \
+    (((struct OsMemNodeHead *)(node))->ptr.prev = (struct OsMemNodeHead *)OS_MEM_GAP_NODE_MAGIC)
+#define OS_MEM_IS_GAP_NODE(node)    \
+    (((struct OsMemNodeHead *)(node))->ptr.prev == (struct OsMemNodeHead *)OS_MEM_GAP_NODE_MAGIC)
+#else
+#define OS_MEM_MARK_GAP_NODE(node)
+#define OS_MEM_IS_GAP_NODE(node)    FALSE
+#endif
+
+STATIC INLINE VOID OsMemFreeNodeAdd(VOID *pool, struct OsMemFreeNodeHead *node);
+STATIC INLINE UINT32 OsMemFree(struct OsMemPoolHead *pool, struct OsMemNodeHead *node);
+
+#if (LOSCFG_MEM_FREE_BY_TASKID == 1 || LOSCFG_TASK_MEM_USED == 1)
+STATIC INLINE VOID OsMemNodeSetTaskID(struct OsMemUsedNodeHead *node)
+{
+    node->header.taskID = LOS_CurTaskIDGet();
+}
+#endif
+STATIC VOID OsAllMemNodeDoHandle(VOID *pool, VOID (*handle)(struct OsMemNodeHead *curNode, VOID *arg), VOID *arg)
+{
+    struct OsMemPoolHead *poolInfo = (struct OsMemPoolHead *)pool;
+    struct OsMemNodeHead *tmpNode = NULL;
+    struct OsMemNodeHead *endNode = NULL;
+    UINT32 intSave = 0;
+
+    if (pool == NULL) {
+        PRINTK("input param is NULL\n");
+        return;
+    }
+    if (LOS_MemIntegrityCheck(pool)) {
+        PRINTK("LOS_MemIntegrityCheck error\n");
+        return;
+    }
+
+    MEM_LOCK(poolInfo, intSave);
+    endNode = OS_MEM_END_NODE(pool, poolInfo->info.totalSize);
+    for (tmpNode = OS_MEM_FIRST_NODE(pool); tmpNode <= endNode; tmpNode = OS_MEM_NEXT_NODE(tmpNode)) {
+        if (tmpNode == endNode) {
+#if OS_MEM_EXPAND_ENABLE
+            UINT32 size;
+            if (OsMemIsLastSentinelNode(endNode) == FALSE) {
+                size = OS_MEM_NODE_GET_SIZE(endNode->sizeAndFlag);
+                tmpNode = OsMemSentinelNodeGet(endNode);
+                endNode = OS_MEM_END_NODE(tmpNode, size);
+                continue;
+            }
+#endif
+            break;
+        }
+        handle(tmpNode, arg);
+    }
+    MEM_UNLOCK(poolInfo, intSave);
+}
+
+#if (LOSCFG_TASK_MEM_USED == 1)
+STATIC VOID GetTaskMemUsedHandle(struct OsMemNodeHead *curNode, VOID *arg)
+{
+    UINT32 *args = (UINT32 *)arg;
+    UINT32 *tskMemInfoBuf = (UINT32 *)(UINTPTR)*args;
+    UINT32 tskMemInfoCnt = *(args + 1);
+#ifndef LOSCFG_MEM_MUL_REGIONS
+    if (OS_MEM_NODE_GET_USED_FLAG(curNode->sizeAndFlag)) {
+#else
+    if (OS_MEM_NODE_GET_USED_FLAG(curNode->sizeAndFlag) && !OS_MEM_IS_GAP_NODE(curNode)) {
+#endif
+        if (curNode->taskID < tskMemInfoCnt) {
+            tskMemInfoBuf[curNode->taskID] += OS_MEM_NODE_GET_SIZE(curNode->sizeAndFlag);
+        }
+    }
+    return;
+}
+
+VOID OsTaskMemUsed(VOID *pool, UINT32 *tskMemInfoBuf, UINT32 tskMemInfoCnt)
+{
+    UINT32 args[2] = {(UINT32)(UINTPTR)tskMemInfoBuf, tskMemInfoCnt};
+    OsAllMemNodeDoHandle(pool, GetTaskMemUsedHandle, (VOID *)args);
+    return;
+}
+#endif
+
+#if (LOSCFG_MEM_WATERLINE == 1)
+STATIC INLINE VOID OsMemWaterUsedRecord(struct OsMemPoolHead *pool, UINT32 size)
+{
+    pool->info.curUsedSize += size;
+    if (pool->info.curUsedSize > pool->info.waterLine) {
+        pool->info.waterLine = pool->info.curUsedSize;
+    }
+}
+#else
+STATIC INLINE VOID OsMemWaterUsedRecord(struct OsMemPoolHead *pool, UINT32 size)
+{
+    (VOID)pool;
+    (VOID)size;
+}
+#endif
+
+#if OS_MEM_EXPAND_ENABLE
+STATIC INLINE struct OsMemNodeHead *OsMemLastSentinelNodeGet(const struct OsMemNodeHead *sentinelNode)
+{
+    struct OsMemNodeHead *node = NULL;
+    VOID *ptr = sentinelNode->ptr.next;
+    UINT32 size = OS_MEM_NODE_GET_SIZE(sentinelNode->sizeAndFlag);
+
+    while ((ptr != NULL) && (size != 0)) {
+        node = OS_MEM_END_NODE(ptr, size);
+        ptr = node->ptr.next;
+        size = OS_MEM_NODE_GET_SIZE(node->sizeAndFlag);
+    }
+
+    return node;
+}
+
+STATIC INLINE BOOL OsMemSentinelNodeCheck(struct OsMemNodeHead *sentinelNode)
+{
+    if (!OS_MEM_NODE_GET_USED_FLAG(sentinelNode->sizeAndFlag)) {
+        return FALSE;
+    }
+
+    if (!OS_MEM_MAGIC_VALID(sentinelNode)) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+STATIC INLINE BOOL OsMemIsLastSentinelNode(struct OsMemNodeHead *sentinelNode)
+{
+    if (OsMemSentinelNodeCheck(sentinelNode) == FALSE) {
+        PRINT_ERR("%s %d, The current sentinel node is invalid\n", __FUNCTION__, __LINE__);
+        return TRUE;
+    }
+
+    if ((OS_MEM_NODE_GET_SIZE(sentinelNode->sizeAndFlag) == 0) ||
+        (sentinelNode->ptr.next == NULL)) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+STATIC INLINE VOID OsMemSentinelNodeSet(struct OsMemNodeHead *sentinelNode, VOID *newNode, UINT32 size)
+{
+    if (sentinelNode->ptr.next != NULL) {
+        sentinelNode = OsMemLastSentinelNodeGet(sentinelNode);
+    }
+
+    sentinelNode->sizeAndFlag = size;
+    sentinelNode->ptr.next = newNode;
+    OS_MEM_NODE_SET_USED_FLAG(sentinelNode->sizeAndFlag);
+    OS_MEM_NODE_SET_LAST_FLAG(sentinelNode->sizeAndFlag);
+}
+
+STATIC INLINE VOID *OsMemSentinelNodeGet(struct OsMemNodeHead *node)
+{
+    if (OsMemSentinelNodeCheck(node) == FALSE) {
+        return NULL;
+    }
+
+    return node->ptr.next;
+}
+
+STATIC INLINE struct OsMemNodeHead *PreSentinelNodeGet(const VOID *pool, const struct OsMemNodeHead *node)
+{
+    UINT32 nextSize;
+    struct OsMemNodeHead *nextNode = NULL;
+    struct OsMemNodeHead *sentinelNode = NULL;
+
+    sentinelNode = OS_MEM_END_NODE(pool, ((struct OsMemPoolHead *)pool)->info.totalSize);
+    while (sentinelNode != NULL) {
+        if (OsMemIsLastSentinelNode(sentinelNode)) {
+            PRINT_ERR("PreSentinelNodeGet can not find node 0x%x\n", node);
+            return NULL;
+        }
+        nextNode = OsMemSentinelNodeGet(sentinelNode);
+        if (nextNode == node) {
+            return sentinelNode;
+        }
+        nextSize = OS_MEM_NODE_GET_SIZE(sentinelNode->sizeAndFlag);
+        sentinelNode = OS_MEM_END_NODE(nextNode, nextSize);
+    }
+
+    return NULL;
+}
+
+STATIC INLINE BOOL TryShrinkPool(const VOID *pool, const struct OsMemNodeHead *node)
+{
+    struct OsMemNodeHead *mySentinel = NULL;
+    struct OsMemNodeHead *preSentinel = NULL;
+    size_t totalSize = (UINTPTR)node->ptr.prev - (UINTPTR)node;
+    size_t nodeSize = OS_MEM_NODE_GET_SIZE(node->sizeAndFlag);
+
+    if (nodeSize != totalSize) {
+        return FALSE;
+    }
+
+    preSentinel = PreSentinelNodeGet(pool, node);
+    if (preSentinel == NULL) {
+        return FALSE;
+    }
+
+    mySentinel = node->ptr.prev;
+    if (OsMemIsLastSentinelNode(mySentinel)) { /* prev node becomes sentinel node */
+        preSentinel->ptr.next = NULL;
+        OsMemSentinelNodeSet(preSentinel, NULL, 0);
+    } else {
+        preSentinel->sizeAndFlag = mySentinel->sizeAndFlag;
+        preSentinel->ptr.next = mySentinel->ptr.next;
+    }
+
+    if (OsMemLargeNodeFree(node) != LOS_OK) {
+        PRINT_ERR("TryShrinkPool free 0x%x failed!\n", node);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+STATIC INLINE INT32 OsMemPoolExpand(VOID *pool, UINT32 size, UINT32 intSave)
+{
+    UINT32 tryCount = MAX_SHRINK_PAGECACHE_TRY;
+    struct OsMemPoolHead *poolInfo = (struct OsMemPoolHead *)pool;
+    struct OsMemNodeHead *newNode = NULL;
+    struct OsMemNodeHead *endNode = NULL;
+
+    size = ROUNDUP(size + OS_MEM_NODE_HEAD_SIZE, PAGE_SIZE);
+    endNode = OS_MEM_END_NODE(pool, poolInfo->info.totalSize);
+
+RETRY:
+    newNode = (struct OsMemNodeHead *)LOS_PhysPagesAllocContiguous(size >> PAGE_SHIFT);
+    if (newNode == NULL) {
+        if (tryCount > 0) {
+            tryCount--;
+            MEM_UNLOCK(poolInfo, intSave);
+            OsTryShrinkMemory(size >> PAGE_SHIFT);
+            MEM_LOCK(poolInfo, intSave);
+            goto RETRY;
+        }
+
+        PRINT_ERR("OsMemPoolExpand alloc failed size = %u\n", size);
+        return -1;
+    }
+    newNode->sizeAndFlag = (size - OS_MEM_NODE_HEAD_SIZE);
+    newNode->ptr.prev = OS_MEM_END_NODE(newNode, size);
+    OsMemSentinelNodeSet(endNode, newNode, size);
+    OsMemFreeNodeAdd(pool, (struct OsMemFreeNodeHead *)newNode);
+
+    endNode = OS_MEM_END_NODE(newNode, size);
+    (VOID)memset(endNode, 0, sizeof(*endNode));
+    endNode->ptr.next = NULL;
+    OS_MEM_SET_MAGIC(endNode);
+    OsMemSentinelNodeSet(endNode, NULL, 0);
+    OsMemWaterUsedRecord(poolInfo, OS_MEM_NODE_HEAD_SIZE);
+
+    return 0;
+}
+
+VOID LOS_MemExpandEnable(VOID *pool)
+{
+    if (pool == NULL) {
+        return;
+    }
+
+    ((struct OsMemPoolHead *)pool)->info.attr |= OS_MEM_POOL_EXPAND_ENABLE;
+}
+#endif
+
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+struct OsMemLeakCheckInfo {
+    struct OsMemNodeHead *node;
+    UINTPTR linkReg[LOSCFG_MEM_RECORD_LR_CNT];
+};
+
+struct OsMemLeakCheckInfo g_leakCheckRecord[LOSCFG_MEM_LEAKCHECK_RECORD_MAX_NUM] = {0};
+STATIC UINT32 g_leakCheckRecordCnt = 0;
+
+STATIC INLINE VOID OsMemLeakCheckInfoRecord(struct OsMemNodeHead *node)
+{
+    struct OsMemLeakCheckInfo *info = &g_leakCheckRecord[g_leakCheckRecordCnt];
+
+    if (!OS_MEM_NODE_GET_LEAK_FLAG(node->sizeAndFlag)) {
+        info->node = node;
+        (VOID)memcpy(info->linkReg, node->linkReg, sizeof(node->linkReg));
+        OS_MEM_NODE_SET_LEAK_FLAG(node->sizeAndFlag);
+        g_leakCheckRecordCnt++;
+        if (g_leakCheckRecordCnt >= LOSCFG_MEM_LEAKCHECK_RECORD_MAX_NUM) {
+            g_leakCheckRecordCnt = 0;
+        }
+    }
+}
+
+STATIC INLINE VOID OsMemLeakCheckInit(VOID)
+{
+    (VOID)memset(g_leakCheckRecord,
+                   0, sizeof(struct OsMemLeakCheckInfo) * LOSCFG_MEM_LEAKCHECK_RECORD_MAX_NUM);
+    g_leakCheckRecordCnt = 0;
+}
+
+STATIC INLINE VOID OsMemLinkRegisterRecord(struct OsMemNodeHead *node)
+{
+    (VOID)memset(node->linkReg, 0, sizeof(node->linkReg));
+    OsBackTraceHookCall(node->linkReg, LOSCFG_MEM_RECORD_LR_CNT, LOSCFG_MEM_OMIT_LR_CNT, 0);
+}
+
+STATIC INLINE VOID OsMemUsedNodePrint(struct OsMemNodeHead *node)
+{
+    UINT32 count;
+
+    if (OS_MEM_NODE_GET_USED_FLAG(node->sizeAndFlag) && !OS_MEM_IS_GAP_NODE(node)) {
+        PRINTK("0x%x: 0x%x ", (UINTPTR)node, OS_MEM_NODE_GET_SIZE(node->sizeAndFlag));
+        for (count = 0; count < LOSCFG_MEM_RECORD_LR_CNT; count++) {
+            PRINTK(" 0x%x ", node->linkReg[count]);
+        }
+        PRINTK("\n");
+
+        OsMemLeakCheckInfoRecord(node);
+    }
+}
+
+STATIC VOID OsMemUsedNodePrintHandle(struct OsMemNodeHead *node, VOID *arg)
+{
+    UNUSED(arg);
+    OsMemUsedNodePrint(node);
+    return;
+}
+
+VOID LOS_MemUsedNodeShow(VOID *pool)
+{
+    UINT32 count;
+
+    PRINTK("\n\rnode          size    ");
+    for (count = 0; count < LOSCFG_MEM_RECORD_LR_CNT; count++) {
+        PRINTK("    LR[%u]   ", count);
+    }
+    PRINTK("\n");
+
+    OsMemLeakCheckInit();
+    OsAllMemNodeDoHandle(pool, OsMemUsedNodePrintHandle, NULL);
+    return;
+}
+
+#if (LOSCFG_KERNEL_PRINTF != 0)
+STATIC VOID OsMemNodeBacktraceInfo(const struct OsMemNodeHead *tmpNode,
+                                   const struct OsMemNodeHead *preNode)
+{
+    int i;
+    PRINTK("\n broken node head LR info: \n");
+    for (i = 0; i < LOSCFG_MEM_RECORD_LR_CNT; i++) {
+        PRINTK(" LR[%d]:0x%x\n", i, tmpNode->linkReg[i]);
+    }
+
+    PRINTK("\n pre node head LR info: \n");
+    for (i = 0; i < LOSCFG_MEM_RECORD_LR_CNT; i++) {
+        PRINTK(" LR[%d]:0x%x\n", i, preNode->linkReg[i]);
+    }
+}
+#endif
+#endif
+
+STATIC INLINE UINT32 OsMemFreeListIndexGet(UINT32 size)
+{
+    UINT32 fl = OsMemFlGet(size);
+    if (fl < OS_MEM_SMALL_BUCKET_COUNT) {
+        return fl;
+    }
+
+    UINT32 sl = OsMemSlGet(size, fl);
+    return (OS_MEM_SMALL_BUCKET_COUNT + ((fl - OS_MEM_SMALL_BUCKET_COUNT) << OS_MEM_SLI) + sl);
+}
+
+STATIC INLINE struct OsMemFreeNodeHead *OsMemFindCurSuitableBlock(struct OsMemPoolHead *poolHead,
+                                        UINT32 index, UINT32 size)
+{
+    struct OsMemFreeNodeHead *node = NULL;
+
+    for (node = poolHead->freeList[index]; node != NULL; node = node->next) {
+        if (node->header.sizeAndFlag >= size) {
+            return node;
+        }
+    }
+
+    return NULL;
+}
+
+STATIC INLINE UINT32 OsMemNotEmptyIndexGet(struct OsMemPoolHead *poolHead, UINT32 index)
+{
+    /* 5: Divide by 32 to calculate the index of the bitmap array. */
+    UINT32 mask = poolHead->freeListBitmap[index >> 5];
+    mask &= ~((1 << (index & OS_MEM_BITMAP_MASK)) - 1);
+    if (mask != 0) {
+        index = OsMemFFS(mask) + (index & ~OS_MEM_BITMAP_MASK);
+        return index;
+    }
+
+    return OS_MEM_FREE_LIST_COUNT;
+}
+
+STATIC INLINE struct OsMemFreeNodeHead *OsMemFindNextSuitableBlock(VOID *pool, UINT32 size, UINT32 *outIndex)
+{
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    UINT32 fl = OsMemFlGet(size);
+    UINT32 sl;
+    UINT32 index, tmp;
+    UINT32 curIndex = OS_MEM_FREE_LIST_COUNT;
+    UINT32 mask;
+
+    do {
+        if (fl < OS_MEM_SMALL_BUCKET_COUNT) {
+            index = fl;
+        } else {
+            sl = OsMemSlGet(size, fl);
+            curIndex = ((fl - OS_MEM_SMALL_BUCKET_COUNT) << OS_MEM_SLI) + sl + OS_MEM_SMALL_BUCKET_COUNT;
+            index = curIndex + 1;
+        }
+
+        tmp = OsMemNotEmptyIndexGet(poolHead, index);
+        if (tmp != OS_MEM_FREE_LIST_COUNT) {
+            index = tmp;
+            goto DONE;
+        }
+
+        for (index = LOS_Align(index + 1, 32); index < OS_MEM_FREE_LIST_COUNT; index += 32) {
+            /* 5: Divide by 32 to calculate the index of the bitmap array. */
+            mask = poolHead->freeListBitmap[index >> 5];
+            if (mask != 0) {
+                index = OsMemFFS(mask) + index;
+                goto DONE;
+            }
+        }
+    } while (0);
+
+    if (curIndex == OS_MEM_FREE_LIST_COUNT) {
+        return NULL;
+    }
+
+    *outIndex = curIndex;
+    return OsMemFindCurSuitableBlock(poolHead, curIndex, size);
+DONE:
+    *outIndex = index;
+    return poolHead->freeList[index];
+}
+
+STATIC INLINE VOID OsMemSetFreeListBit(struct OsMemPoolHead *head, UINT32 index)
+{
+    /* 5: Divide by 32 to calculate the index of the bitmap array. */
+    head->freeListBitmap[index >> 5] |= 1U << (index & 0x1f);
+}
+
+STATIC INLINE VOID OsMemClearFreeListBit(struct OsMemPoolHead *head, UINT32 index)
+{
+    /* 5: Divide by 32 to calculate the index of the bitmap array. */
+    head->freeListBitmap[index >> 5] &= ~(1U << (index & 0x1f));
+}
+
+STATIC INLINE VOID OsMemListAdd(struct OsMemPoolHead *pool, UINT32 listIndex, struct OsMemFreeNodeHead *node)
+{
+    struct OsMemFreeNodeHead *firstNode = pool->freeList[listIndex];
+    if (firstNode != NULL) {
+        firstNode->prev = node;
+    }
+    node->prev = NULL;
+    node->next = firstNode;
+    pool->freeList[listIndex] = node;
+    OsMemSetFreeListBit(pool, listIndex);
+    OS_MEM_SET_MAGIC(&node->header);
+}
+
+STATIC INLINE VOID OsMemListDelete(struct OsMemPoolHead *pool, UINT32 listIndex, struct OsMemFreeNodeHead *node)
+{
+    if (node == pool->freeList[listIndex]) {
+        pool->freeList[listIndex] = node->next;
+        if (node->next == NULL) {
+            OsMemClearFreeListBit(pool, listIndex);
+        } else {
+            node->next->prev = NULL;
+        }
+    } else {
+        node->prev->next = node->next;
+        if (node->next != NULL) {
+            node->next->prev = node->prev;
+        }
+    }
+    OS_MEM_SET_MAGIC(&node->header);
+}
+
+STATIC INLINE VOID OsMemFreeNodeAdd(VOID *pool, struct OsMemFreeNodeHead *node)
+{
+    UINT32 index = OsMemFreeListIndexGet(node->header.sizeAndFlag);
+    if (index >= OS_MEM_FREE_LIST_COUNT) {
+        LOS_Panic("The index of free lists is error, index = %u\n", index);
+    }
+    OsMemListAdd(pool, index, node);
+}
+
+STATIC INLINE VOID OsMemFreeNodeDelete(VOID *pool, struct OsMemFreeNodeHead *node)
+{
+    UINT32 index = OsMemFreeListIndexGet(node->header.sizeAndFlag);
+    OsMemListDelete(pool, index, node);
+}
+
+STATIC INLINE struct OsMemNodeHead *OsMemFreeNodeGet(VOID *pool, UINT32 size)
+{
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    UINT32 index;
+    struct OsMemFreeNodeHead *firstNode = OsMemFindNextSuitableBlock(pool, size, &index);
+    if (firstNode == NULL) {
+        return NULL;
+    }
+
+    OsMemListDelete(poolHead, index, firstNode);
+
+    return &firstNode->header;
+}
+
+STATIC INLINE VOID OsMemMergeNode(struct OsMemNodeHead *node)
+{
+    struct OsMemNodeHead *nextNode = NULL;
+
+    node->ptr.prev->sizeAndFlag += node->sizeAndFlag;
+    nextNode = (struct OsMemNodeHead *)((UINTPTR)node + node->sizeAndFlag);
+    if (!OS_MEM_NODE_GET_LAST_FLAG(nextNode->sizeAndFlag) && !OS_MEM_IS_GAP_NODE(nextNode)) {
+        nextNode->ptr.prev = node->ptr.prev;
+    }
+}
+
+STATIC INLINE VOID OsMemSplitNode(VOID *pool, struct OsMemNodeHead *allocNode, UINT32 allocSize)
+{
+    struct OsMemFreeNodeHead *newFreeNode = NULL;
+    struct OsMemNodeHead *nextNode = NULL;
+
+    newFreeNode = (struct OsMemFreeNodeHead *)(VOID *)((UINT8 *)allocNode + allocSize);
+    newFreeNode->header.ptr.prev = allocNode;
+    newFreeNode->header.sizeAndFlag = allocNode->sizeAndFlag - allocSize;
+    allocNode->sizeAndFlag = allocSize;
+    nextNode = OS_MEM_NEXT_NODE(&newFreeNode->header);
+    if (!OS_MEM_NODE_GET_LAST_FLAG(nextNode->sizeAndFlag) && !OS_MEM_IS_GAP_NODE(nextNode)) {
+        nextNode->ptr.prev = &newFreeNode->header;
+        if (!OS_MEM_NODE_GET_USED_FLAG(nextNode->sizeAndFlag)) {
+            OsMemFreeNodeDelete(pool, (struct OsMemFreeNodeHead *)nextNode);
+            OsMemMergeNode(nextNode);
+        }
+    }
+
+    OsMemFreeNodeAdd(pool, newFreeNode);
+}
+
+STATIC INLINE VOID *OsMemCreateUsedNode(VOID *addr)
+{
+    struct OsMemUsedNodeHead *node = (struct OsMemUsedNodeHead *)addr;
+
+#if (LOSCFG_MEM_FREE_BY_TASKID == 1 || LOSCFG_TASK_MEM_USED == 1)
+    OsMemNodeSetTaskID(node);
+#endif
+
+    return node + 1;
+}
+
+STATIC UINT32 OsMemPoolInit(VOID *pool, UINT32 size)
+{
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    struct OsMemNodeHead *newNode = NULL;
+    struct OsMemNodeHead *endNode = NULL;
+
+    (VOID)memset(poolHead, 0, sizeof(struct OsMemPoolHead));
+
+    poolHead->info.pool = pool;
+    poolHead->info.totalSize = size;
+    /* default attr: lock, not expand. */
+    poolHead->info.attr &= ~(OS_MEM_POOL_UNLOCK_ENABLE | OS_MEM_POOL_EXPAND_ENABLE);
+
+    newNode = OS_MEM_FIRST_NODE(pool);
+    newNode->sizeAndFlag = (size - sizeof(struct OsMemPoolHead) - OS_MEM_NODE_HEAD_SIZE);
+    newNode->ptr.prev = OS_MEM_END_NODE(pool, size);
+    OS_MEM_SET_MAGIC(newNode);
+    OsMemFreeNodeAdd(pool, (struct OsMemFreeNodeHead *)newNode);
+
+    /* The last mem node */
+    endNode = OS_MEM_END_NODE(pool, size);
+    OS_MEM_SET_MAGIC(endNode);
+#if OS_MEM_EXPAND_ENABLE
+    endNode->ptr.next = NULL;
+    OsMemSentinelNodeSet(endNode, NULL, 0);
+#else
+    endNode->sizeAndFlag = 0;
+    endNode->ptr.prev = newNode;
+    OS_MEM_NODE_SET_USED_FLAG(endNode->sizeAndFlag);
+#endif
+#if (LOSCFG_MEM_WATERLINE == 1)
+    poolHead->info.curUsedSize = sizeof(struct OsMemPoolHead) + OS_MEM_NODE_HEAD_SIZE;
+    poolHead->info.waterLine = poolHead->info.curUsedSize;
+#endif
+
+    return LOS_OK;
+}
+
+#if (LOSCFG_MEM_MUL_POOL == 1)
+STATIC VOID OsMemPoolDeinit(VOID *pool)
+{
+    (VOID)memset(pool, 0, sizeof(struct OsMemPoolHead));
+}
+
+STATIC UINT32 OsMemPoolAdd(VOID *pool, UINT32 size)
+{
+    VOID *nextPool = g_poolHead;
+    VOID *curPool = g_poolHead;
+    UINTPTR poolEnd;
+    while (nextPool != NULL) {
+        poolEnd = (UINTPTR)nextPool + LOS_MemPoolSizeGet(nextPool);
+        if (((pool <= nextPool) && (((UINTPTR)pool + size) > (UINTPTR)nextPool)) ||
+            (((UINTPTR)pool < poolEnd) && (((UINTPTR)pool + size) >= poolEnd))) {
+            PRINT_ERR("pool [0x%x, 0x%x) conflict with pool [0x%x, 0x%x)\n", (UINTPTR)pool,
+                      (UINTPTR)pool + size, (UINTPTR)nextPool, (UINTPTR)nextPool + LOS_MemPoolSizeGet(nextPool));
+            return LOS_NOK;
+        }
+        curPool = nextPool;
+        nextPool = ((struct OsMemPoolHead *)nextPool)->nextPool;
+    }
+
+    if (g_poolHead == NULL) {
+        g_poolHead = pool;
+    } else {
+        ((struct OsMemPoolHead *)curPool)->nextPool = pool;
+    }
+
+    ((struct OsMemPoolHead *)pool)->nextPool = NULL;
+    return LOS_OK;
+}
+
+STATIC UINT32 OsMemPoolDelete(VOID *pool)
+{
+    UINT32 ret = LOS_NOK;
+    VOID *nextPool = NULL;
+    VOID *curPool = NULL;
+
+    do {
+        if (pool == g_poolHead) {
+            g_poolHead = ((struct OsMemPoolHead *)g_poolHead)->nextPool;
+            ret = LOS_OK;
+            break;
+        }
+
+        curPool = g_poolHead;
+        nextPool = g_poolHead;
+        while (nextPool != NULL) {
+            if (pool == nextPool) {
+                ((struct OsMemPoolHead *)curPool)->nextPool = ((struct OsMemPoolHead *)nextPool)->nextPool;
+                ret = LOS_OK;
+                break;
+            }
+            curPool = nextPool;
+            nextPool = ((struct OsMemPoolHead *)nextPool)->nextPool;
+        }
+    } while (0);
+
+    return ret;
+}
+#endif
+
+UINT32 LOS_MemInit(VOID *pool, UINT32 size)
+{
+    if ((pool == NULL) || (size <= OS_MEM_MIN_POOL_SIZE)) {
+        return OS_ERROR;
+    }
+
+    if (((UINTPTR)pool & (OS_MEM_ALIGN_SIZE - 1)) || \
+        (size & (OS_MEM_ALIGN_SIZE - 1))) {
+        PRINT_ERR("LiteOS heap memory address or size configured not aligned:address:0x%x,size:0x%x, alignsize:%u\n", \
+                  (UINTPTR)pool, size, OS_MEM_ALIGN_SIZE);
+        return OS_ERROR;
+    }
+
+    if (OsMemPoolInit(pool, size)) {
+        return OS_ERROR;
+    }
+
+#if (LOSCFG_MEM_MUL_POOL == 1)
+    if (OsMemPoolAdd(pool, size)) {
+        (VOID)OsMemPoolDeinit(pool);
+        return OS_ERROR;
+    }
+#endif
+
+    // OsHookCall(LOS_HOOK_TYPE_MEM_INIT, pool, size);
+
+    return LOS_OK;
+}
+
+#if (LOSCFG_MEM_MUL_POOL == 1)
+UINT32 LOS_MemDeInit(VOID *pool)
+{
+    if (pool == NULL) {
+        return OS_ERROR;
+    }
+
+    if (OsMemPoolDelete(pool)) {
+        return OS_ERROR;
+    }
+
+    OsMemPoolDeinit(pool);
+
+    OsHookCall(LOS_HOOK_TYPE_MEM_DEINIT, pool);
+
+    return LOS_OK;
+}
+
+UINT32 LOS_MemPoolList(VOID)
+{
+    VOID *nextPool = g_poolHead;
+    UINT32 index = 0;
+    while (nextPool != NULL) {
+        PRINTK("pool%u :\n", index);
+        index++;
+        OsMemInfoPrint(nextPool);
+        nextPool = ((struct OsMemPoolHead *)nextPool)->nextPool;
+    }
+    return index;
+}
+#endif
+
+STATIC INLINE VOID *OsMemAlloc(struct OsMemPoolHead *pool, UINT32 size, UINT32 intSave)
+{
+    struct OsMemNodeHead *allocNode = NULL;
+
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+    if (OsMemAllocCheck(pool, intSave) == LOS_NOK) {
+        return NULL;
+    }
+#endif
+
+    UINT32 allocSize = OS_MEM_ALIGN(size + OS_MEM_NODE_HEAD_SIZE, OS_MEM_ALIGN_SIZE);
+#if OS_MEM_EXPAND_ENABLE
+retry:
+#endif
+    allocNode = OsMemFreeNodeGet(pool, allocSize);
+    if (allocNode == NULL) {
+#if OS_MEM_EXPAND_ENABLE
+        if (pool->info.attr & OS_MEM_POOL_EXPAND_ENABLE) {
+            INT32 ret = OsMemPoolExpand(pool, allocSize, intSave);
+            if (ret == 0) {
+                goto retry;
+            }
+        }
+#endif
+        PRINT_ERR("---------------------------------------------------"
+                  "--------------------------------------------------------\n");
+        MEM_UNLOCK(pool, intSave);
+        // OsMemInfoPrint(pool);
+        MEM_LOCK(pool, intSave);
+        PRINT_ERR("[%s] No suitable free block, require free node size: 0x%x\n", __FUNCTION__, allocSize);
+        PRINT_ERR("----------------------------------------------------"
+                  "-------------------------------------------------------\n");
+        return NULL;
+    }
+
+    if ((allocSize + OS_MEM_MIN_LEFT_SIZE) <= allocNode->sizeAndFlag) {
+        OsMemSplitNode(pool, allocNode, allocSize);
+    }
+
+    OS_MEM_NODE_SET_USED_FLAG(allocNode->sizeAndFlag);
+    OsMemWaterUsedRecord(pool, OS_MEM_NODE_GET_SIZE(allocNode->sizeAndFlag));
+
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+    OsMemLinkRegisterRecord(allocNode);
+#endif
+    return OsMemCreateUsedNode((VOID *)allocNode);
+}
+
+VOID *LOS_MemAlloc(VOID *pool, UINT32 size)
+{
+    if ((pool == NULL) || (size == 0)) {
+        return NULL;
+    }
+
+    if (size < OS_MEM_MIN_ALLOC_SIZE) {
+        size = OS_MEM_MIN_ALLOC_SIZE;
+    }
+
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    VOID *ptr = NULL;
+    UINT32 intSave = 0;
+
+    MEM_LOCK(poolHead, intSave);
+    do {
+        if (OS_MEM_NODE_GET_USED_FLAG(size) || OS_MEM_NODE_GET_ALIGNED_FLAG(size)) {
+            break;
+        }
+        ptr = OsMemAlloc(poolHead, size, intSave);
+    } while (0);
+    MEM_UNLOCK(poolHead, intSave);
+
+    // OsHookCall(LOS_HOOK_TYPE_MEM_ALLOC, pool, ptr, size);
+
+    return ptr;
+}
+
+VOID *LOS_MemAllocAlign(VOID *pool, UINT32 size, UINT32 boundary)
+{
+    UINT32 gapSize;
+
+    if ((pool == NULL) || (size == 0) || (boundary == 0) || !OS_MEM_IS_POW_TWO(boundary) ||
+        !OS_MEM_IS_ALIGNED(boundary, sizeof(VOID *))) {
+        return NULL;
+    }
+
+    if (size < OS_MEM_MIN_ALLOC_SIZE) {
+        size = OS_MEM_MIN_ALLOC_SIZE;
+    }
+
+    /*
+     * sizeof(gapSize) bytes stores offset between alignedPtr and ptr,
+     * the ptr has been OS_MEM_ALIGN_SIZE(4 or 8) aligned, so maximum
+     * offset between alignedPtr and ptr is boundary - OS_MEM_ALIGN_SIZE
+     */
+    if ((boundary - sizeof(gapSize)) > ((UINT32)(-1) - size)) {
+        return NULL;
+    }
+
+    UINT32 useSize = (size + boundary) - sizeof(gapSize);
+    if (OS_MEM_NODE_GET_USED_FLAG(useSize) || OS_MEM_NODE_GET_ALIGNED_FLAG(useSize)) {
+        return NULL;
+    }
+
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    UINT32 intSave = 0;
+    VOID *ptr = NULL;
+    VOID *alignedPtr = NULL;
+
+    MEM_LOCK(poolHead, intSave);
+    do {
+        ptr = OsMemAlloc(pool, useSize, intSave);
+        alignedPtr = (VOID *)OS_MEM_ALIGN(ptr, boundary);
+        if (ptr == alignedPtr) {
+            break;
+        }
+
+        /* store gapSize in address (ptr - 4), it will be checked while free */
+        gapSize = (UINT32)((UINTPTR)alignedPtr - (UINTPTR)ptr);
+        struct OsMemUsedNodeHead *allocNode = (struct OsMemUsedNodeHead *)ptr - 1;
+        OS_MEM_NODE_SET_ALIGNED_FLAG(allocNode->header.sizeAndFlag);
+        OS_MEM_SET_GAPSIZE_ALIGNED_FLAG(gapSize);
+        *(UINT32 *)((UINTPTR)alignedPtr - sizeof(gapSize)) = gapSize;
+        ptr = alignedPtr;
+    } while (0);
+    MEM_UNLOCK(poolHead, intSave);
+
+    // OsHookCall(LOS_HOOK_TYPE_MEM_ALLOCALIGN, pool, ptr, size, boundary);
+
+    return ptr;
+}
+
+STATIC INLINE BOOL OsMemAddrValidCheck(const struct OsMemPoolHead *pool, const VOID *addr)
+{
+    UINT32 size;
+
+    size = pool->info.totalSize;
+    if (OS_MEM_MIDDLE_ADDR_OPEN_END(pool + 1, addr, (UINTPTR)pool + size)) {
+        return TRUE;
+    }
+#if OS_MEM_EXPAND_ENABLE
+    struct OsMemNodeHead *node = NULL;
+    struct OsMemNodeHead *sentinel = OS_MEM_END_NODE(pool, size);
+    while (OsMemIsLastSentinelNode(sentinel) == FALSE) {
+        size = OS_MEM_NODE_GET_SIZE(sentinel->sizeAndFlag);
+        node = OsMemSentinelNodeGet(sentinel);
+        sentinel = OS_MEM_END_NODE(node, size);
+        if (OS_MEM_MIDDLE_ADDR_OPEN_END(node, addr, (UINTPTR)node + size)) {
+            return TRUE;
+        }
+    }
+#endif
+    return FALSE;
+}
+
+STATIC INLINE BOOL OsMemIsNodeValid(const struct OsMemNodeHead *node, const struct OsMemNodeHead *startNode,
+                                    const struct OsMemNodeHead *endNode,
+                                    const struct OsMemPoolHead *poolInfo)
+{
+    if (!OS_MEM_MIDDLE_ADDR(startNode, node, endNode)) {
+        return FALSE;
+    }
+
+    if (OS_MEM_NODE_GET_USED_FLAG(node->sizeAndFlag)) {
+        if (!OS_MEM_MAGIC_VALID(node)) {
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    if (!OsMemAddrValidCheck(poolInfo, node->ptr.prev)) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+STATIC UINT32 OsMemCheckUsedNode(const struct OsMemPoolHead *pool, const struct OsMemNodeHead *node)
+{
+    struct OsMemNodeHead *startNode = (struct OsMemNodeHead *)OS_MEM_FIRST_NODE(pool);
+    struct OsMemNodeHead *endNode = (struct OsMemNodeHead *)OS_MEM_END_NODE(pool, pool->info.totalSize);
+    struct OsMemNodeHead *nextNode = NULL;
+    BOOL doneFlag = FALSE;
+
+    do {
+        do {
+            if (OS_MEM_IS_GAP_NODE(node)) {
+                break;
+            }
+
+            if (!OsMemIsNodeValid(node, startNode, endNode, pool)) {
+                break;
+            }
+
+            if (!OS_MEM_NODE_GET_USED_FLAG(node->sizeAndFlag)) {
+                break;
+            }
+
+            nextNode = OS_MEM_NEXT_NODE(node);
+            if (!OsMemIsNodeValid(nextNode, startNode, endNode, pool)) {
+                break;
+            }
+
+            if (!OS_MEM_NODE_GET_LAST_FLAG(nextNode->sizeAndFlag) && !OS_MEM_IS_GAP_NODE(nextNode)) {
+                if (nextNode->ptr.prev != node) {
+                    break;
+                }
+            }
+
+            if ((node != startNode) &&
+                ((!OsMemIsNodeValid(node->ptr.prev, startNode, endNode, pool)) ||
+                (OS_MEM_NEXT_NODE(node->ptr.prev) != node))) {
+                break;
+            }
+            doneFlag = TRUE;
+        } while (0);
+
+        if (!doneFlag) {
+#if OS_MEM_EXPAND_ENABLE
+            if (OsMemIsLastSentinelNode(endNode) == FALSE) {
+                startNode = OsMemSentinelNodeGet(endNode);
+                endNode = OS_MEM_END_NODE(startNode, OS_MEM_NODE_GET_SIZE(endNode->sizeAndFlag));
+                continue;
+            }
+#endif
+            return LOS_NOK;
+        }
+    } while (!doneFlag);
+
+    return LOS_OK;
+}
+
+STATIC INLINE UINT32 OsMemFree(struct OsMemPoolHead *pool, struct OsMemNodeHead *node)
+{
+    UINT32 ret = OsMemCheckUsedNode(pool, node);
+    if (ret != LOS_OK) {
+        PRINT_ERR("OsMemFree check error!\n");
+        return ret;
+    }
+
+#if (LOSCFG_MEM_WATERLINE == 1)
+    pool->info.curUsedSize -= OS_MEM_NODE_GET_SIZE(node->sizeAndFlag);
+#endif
+
+    node->sizeAndFlag = OS_MEM_NODE_GET_SIZE(node->sizeAndFlag);
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+    OsMemLinkRegisterRecord(node);
+#endif
+    struct OsMemNodeHead *preNode = node->ptr.prev; /* merage preNode */
+    if ((preNode != NULL) && !OS_MEM_NODE_GET_USED_FLAG(preNode->sizeAndFlag)) {
+        OsMemFreeNodeDelete(pool, (struct OsMemFreeNodeHead *)preNode);
+        OsMemMergeNode(node);
+        node = preNode;
+    }
+
+    struct OsMemNodeHead *nextNode = OS_MEM_NEXT_NODE(node); /* merage nextNode */
+    if ((nextNode != NULL) && !OS_MEM_NODE_GET_USED_FLAG(nextNode->sizeAndFlag)) {
+        OsMemFreeNodeDelete(pool, (struct OsMemFreeNodeHead *)nextNode);
+        OsMemMergeNode(nextNode);
+    }
+
+#if OS_MEM_EXPAND_ENABLE
+    if (pool->info.attr & OS_MEM_POOL_EXPAND_ENABLE) {
+        struct OsMemNodeHead *firstNode = OS_MEM_FIRST_NODE(pool);
+        /* if this is a expand head node, and all unused, free it to pmm */
+        if ((node->prev > node) && (node != firstNode)) {
+            if (TryShrinkPool(pool, node)) {
+                return LOS_OK;
+            }
+        }
+    }
+#endif
+
+    OsMemFreeNodeAdd(pool, (struct OsMemFreeNodeHead *)node);
+
+    return ret;
+}
+
+STATIC INLINE VOID *OsGetRealPtr(const VOID *pool, VOID *ptr)
+{
+    VOID *realPtr = ptr;
+    UINT32 gapSize = *((UINT32 *)((UINTPTR)ptr - sizeof(UINT32)));
+
+    if (OS_MEM_GAPSIZE_CHECK(gapSize)) {
+        PRINT_ERR("[%s:%d]gapSize:0x%x error\n", __FUNCTION__, __LINE__, gapSize);
+        return NULL;
+    }
+
+    if (OS_MEM_GET_GAPSIZE_ALIGNED_FLAG(gapSize)) {
+        gapSize = OS_MEM_GET_ALIGNED_GAPSIZE(gapSize);
+        if ((gapSize & (OS_MEM_ALIGN_SIZE - 1)) ||
+            (gapSize > ((UINTPTR)ptr - OS_MEM_NODE_HEAD_SIZE - (UINTPTR)pool))) {
+            PRINT_ERR("[%s:%d]gapSize:0x%x error\n", __FUNCTION__, __LINE__, gapSize);
+            return NULL;
+        }
+        realPtr = (VOID *)((UINTPTR)ptr - (UINTPTR)gapSize);
+    }
+    return realPtr;
+}
+
+UINT32 LOS_MemFree(VOID *pool, VOID *ptr)
+{
+    if ((pool == NULL) || (ptr == NULL) || !OS_MEM_IS_ALIGNED(pool, sizeof(VOID *)) ||
+        !OS_MEM_IS_ALIGNED(ptr, sizeof(VOID *))) {
+        return LOS_NOK;
+    }
+
+    // OsHookCall(LOS_HOOK_TYPE_MEM_FREE, pool, ptr);
+
+    UINT32 ret = LOS_NOK;
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    struct OsMemNodeHead *node = NULL;
+    UINT32 intSave = 0;
+
+    MEM_LOCK(poolHead, intSave);
+    do {
+        ptr = OsGetRealPtr(pool, ptr);
+        if (ptr == NULL) {
+            break;
+        }
+        node = (struct OsMemNodeHead *)((UINTPTR)ptr - OS_MEM_NODE_HEAD_SIZE);
+        ret = OsMemFree(poolHead, node);
+    } while (0);
+    MEM_UNLOCK(poolHead, intSave);
+
+    return ret;
+}
+
+STATIC INLINE VOID OsMemReAllocSmaller(VOID *pool, UINT32 allocSize, struct OsMemNodeHead *node, UINT32 nodeSize)
+{
+#if (LOSCFG_MEM_WATERLINE == 1)
+    struct OsMemPoolHead *poolInfo = (struct OsMemPoolHead *)pool;
+#endif
+    node->sizeAndFlag = nodeSize;
+    if ((allocSize + OS_MEM_MIN_LEFT_SIZE) <= nodeSize) {
+        OsMemSplitNode(pool, node, allocSize);
+#if (LOSCFG_MEM_WATERLINE == 1)
+        poolInfo->info.curUsedSize -= nodeSize - allocSize;
+#endif
+    }
+    OS_MEM_NODE_SET_USED_FLAG(node->sizeAndFlag);
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+    OsMemLinkRegisterRecord(node);
+#endif
+}
+
+STATIC INLINE VOID OsMemMergeNodeForReAllocBigger(VOID *pool, UINT32 allocSize, struct OsMemNodeHead *node,
+                                                  UINT32 nodeSize, struct OsMemNodeHead *nextNode)
+{
+    node->sizeAndFlag = nodeSize;
+    OsMemFreeNodeDelete(pool, (struct OsMemFreeNodeHead *)nextNode);
+    OsMemMergeNode(nextNode);
+    if ((allocSize + OS_MEM_MIN_LEFT_SIZE) <= node->sizeAndFlag) {
+        OsMemSplitNode(pool, node, allocSize);
+    }
+    OS_MEM_NODE_SET_USED_FLAG(node->sizeAndFlag);
+    OsMemWaterUsedRecord((struct OsMemPoolHead *)pool, node->sizeAndFlag - nodeSize);
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+    OsMemLinkRegisterRecord(node);
+#endif
+}
+
+STATIC INLINE VOID *OsMemRealloc(struct OsMemPoolHead *pool, const VOID *ptr,
+                struct OsMemNodeHead *node, UINT32 size, UINT32 intSave)
+{
+    struct OsMemNodeHead *nextNode = NULL;
+    UINT32 allocSize = OS_MEM_ALIGN(size + OS_MEM_NODE_HEAD_SIZE, OS_MEM_ALIGN_SIZE);
+    UINT32 nodeSize = OS_MEM_NODE_GET_SIZE(node->sizeAndFlag);
+    VOID *tmpPtr = NULL;
+
+    if (nodeSize >= allocSize) {
+        OsMemReAllocSmaller(pool, allocSize, node, nodeSize);
+        return (VOID *)ptr;
+    }
+
+    nextNode = OS_MEM_NEXT_NODE(node);
+    if (!OS_MEM_NODE_GET_USED_FLAG(nextNode->sizeAndFlag) &&
+        ((nextNode->sizeAndFlag + nodeSize) >= allocSize)) {
+        OsMemMergeNodeForReAllocBigger(pool, allocSize, node, nodeSize, nextNode);
+        return (VOID *)ptr;
+    }
+
+    tmpPtr = OsMemAlloc(pool, size, intSave);
+    if (tmpPtr != NULL) {
+        if (memcpy(tmpPtr, ptr, (nodeSize - OS_MEM_NODE_HEAD_SIZE)) != 0 /* EOK */) {
+            MEM_UNLOCK(pool, intSave);
+            (VOID)LOS_MemFree((VOID *)pool, (VOID *)tmpPtr);
+            MEM_LOCK(pool, intSave);
+            return NULL;
+        }
+        (VOID)OsMemFree(pool, node);
+    }
+    return tmpPtr;
+}
+
+VOID *LOS_MemRealloc(VOID *pool, VOID *ptr, UINT32 size)
+{
+    if ((pool == NULL) || OS_MEM_NODE_GET_USED_FLAG(size) || OS_MEM_NODE_GET_ALIGNED_FLAG(size)) {
+        return NULL;
+    }
+
+    // OsHookCall(LOS_HOOK_TYPE_MEM_REALLOC, pool, ptr, size);
+
+    if (ptr == NULL) {
+        return LOS_MemAlloc(pool, size);
+    }
+
+    if (size == 0) {
+        (VOID)LOS_MemFree(pool, ptr);
+        return NULL;
+    }
+
+    if (size < OS_MEM_MIN_ALLOC_SIZE) {
+        size = OS_MEM_MIN_ALLOC_SIZE;
+    }
+
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    struct OsMemNodeHead *node = NULL;
+    VOID *newPtr = NULL;
+    UINT32 intSave = 0;
+
+    MEM_LOCK(poolHead, intSave);
+    do {
+        ptr = OsGetRealPtr(pool, ptr);
+        if (ptr == NULL) {
+            break;
+        }
+
+        node = (struct OsMemNodeHead *)((UINTPTR)ptr - OS_MEM_NODE_HEAD_SIZE);
+        if (OsMemCheckUsedNode(pool, node) != LOS_OK) {
+            break;
+        }
+
+        newPtr = OsMemRealloc(pool, ptr, node, size, intSave);
+    } while (0);
+    MEM_UNLOCK(poolHead, intSave);
+
+    return newPtr;
+}
+
+#if (LOSCFG_MEM_FREE_BY_TASKID == 1)
+STATIC VOID MemNodeFreeByTaskIDHandle(struct OsMemNodeHead *curNode, VOID *arg)
+{
+    UINT32 *args = (UINT32 *)arg;
+    UINT32 taskID = *args;
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)(UINTPTR)(*(args + 1));
+    struct OsMemUsedNodeHead *node = NULL;
+    if (!OS_MEM_NODE_GET_USED_FLAG(curNode->sizeAndFlag)) {
+        return;
+    }
+
+    node = (struct OsMemUsedNodeHead *)curNode;
+    if (node->header.taskID == taskID) {
+        OsMemFree(poolHead, &node->header);
+    }
+    return;
+}
+
+UINT32 LOS_MemFreeByTaskID(VOID *pool, UINT32 taskID)
+{
+    UINT32 args[2] = { taskID, (UINT32)(UINTPTR)pool };
+    if (pool == NULL) {
+        return OS_ERROR;
+    }
+
+    if (taskID >= LOSCFG_BASE_CORE_TSK_LIMIT) {
+        return OS_ERROR;
+    }
+
+    OsAllMemNodeDoHandle(pool, MemNodeFreeByTaskIDHandle, (VOID *)args);
+
+    return LOS_OK;
+}
+#endif
+
+UINT32 LOS_MemPoolSizeGet(const VOID *pool)
+{
+    UINT32 count = 0;
+
+    if (pool == NULL) {
+        return LOS_NOK;
+    }
+
+    count += ((struct OsMemPoolHead *)pool)->info.totalSize;
+#if (LOSCFG_MEM_MUL_REGIONS == 1)
+    count -= ((struct OsMemPoolHead *)pool)->info.totalGapSize;
+#endif
+
+#if OS_MEM_EXPAND_ENABLE
+    UINT32 size;
+    struct OsMemNodeHead *node = NULL;
+    struct OsMemNodeHead *sentinel = OS_MEM_END_NODE(pool, count);
+
+    while (OsMemIsLastSentinelNode(sentinel) == FALSE) {
+        size = OS_MEM_NODE_GET_SIZE(sentinel->sizeAndFlag);
+        node = OsMemSentinelNodeGet(sentinel);
+        sentinel = OS_MEM_END_NODE(node, size);
+        count += size;
+    }
+#endif
+    return count;
+}
+
+STATIC VOID MemUsedGetHandle(struct OsMemNodeHead *curNode, VOID *arg)
+{
+    UINT32 *memUsed = (UINT32 *)arg;
+    if (OS_MEM_IS_GAP_NODE(curNode)) {
+        *memUsed += OS_MEM_NODE_HEAD_SIZE;
+    } else if (OS_MEM_NODE_GET_USED_FLAG(curNode->sizeAndFlag)) {
+        *memUsed += OS_MEM_NODE_GET_SIZE(curNode->sizeAndFlag);
+    }
+    return;
+}
+
+UINT32 LOS_MemTotalUsedGet(VOID *pool)
+{
+    UINT32 memUsed = 0;
+
+    if (pool == NULL) {
+        return LOS_NOK;
+    }
+
+    OsAllMemNodeDoHandle(pool, MemUsedGetHandle, (VOID *)&memUsed);
+
+    return memUsed;
+}
+
+STATIC INLINE VOID OsMemMagicCheckPrint(struct OsMemNodeHead **tmpNode)
+{
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+    PRINT_ERR("[%s], %d, memory check error!\n"
+              "memory used but magic num wrong, magic num = 0x%x\n",
+              __FUNCTION__, __LINE__, (*tmpNode)->magic);
+#endif
+}
+
+STATIC UINT32 OsMemAddrValidCheckPrint(const VOID *pool, struct OsMemFreeNodeHead **tmpNode)
+{
+    if (((*tmpNode)->prev != NULL) && !OsMemAddrValidCheck(pool, (*tmpNode)->prev)) {
+        PRINT_ERR("[%s], %d, memory check error!\n"
+                  " freeNode.prev: %p is out of legal mem range\n",
+                  __FUNCTION__, __LINE__, (*tmpNode)->prev);
+        return LOS_NOK;
+    }
+    if (((*tmpNode)->next != NULL) && !OsMemAddrValidCheck(pool, (*tmpNode)->next)) {
+        PRINT_ERR("[%s], %d, memory check error!\n"
+                  " freeNode.next: %p is out of legal mem range\n",
+                  __FUNCTION__, __LINE__, (*tmpNode)->next);
+        return LOS_NOK;
+    }
+    return LOS_OK;
+}
+
+STATIC UINT32 OsMemIntegrityCheckSub(struct OsMemNodeHead **tmpNode, const VOID *pool,
+                const struct OsMemNodeHead *endNode)
+{
+    if (!OS_MEM_MAGIC_VALID(*tmpNode)) {
+        OsMemMagicCheckPrint(tmpNode);
+        return LOS_NOK;
+    }
+
+    if (!OsMemAddrValidCheck(pool, (*tmpNode)->ptr.prev)) {
+        PRINT_ERR("[%s], %d, memory check error!\n"
+                  " node prev: %p is out of legal mem range\n",
+                  __FUNCTION__, __LINE__, (*tmpNode)->ptr.next);
+        return LOS_NOK;
+    }
+
+    if (!OS_MEM_NODE_GET_USED_FLAG((*tmpNode)->sizeAndFlag)) { /* is free node, check free node range */
+        if (OsMemAddrValidCheckPrint(pool, (struct OsMemFreeNodeHead **)tmpNode)) {
+            return LOS_NOK;
+        }
+    }
+
+    return LOS_OK;
+}
+
+STATIC UINT32 OsMemFreeListNodeCheck(const struct OsMemPoolHead *pool,
+                const struct OsMemFreeNodeHead *node)
+{
+    if (!OsMemAddrValidCheck(pool, node) ||
+        ((node->prev != NULL) && !OsMemAddrValidCheck(pool, node->prev)) ||
+        ((node->next != NULL) && !OsMemAddrValidCheck(pool, node->next)) ||
+        !OsMemAddrValidCheck(pool, node->header.ptr.prev)) {
+        return LOS_NOK;
+    }
+
+    if (!OS_MEM_IS_ALIGNED(node, sizeof(VOID *)) ||
+        !OS_MEM_IS_ALIGNED(node->prev, sizeof(VOID *)) ||
+        !OS_MEM_IS_ALIGNED(node->next, sizeof(VOID *)) ||
+        !OS_MEM_IS_ALIGNED(node->header.ptr.prev, sizeof(VOID *))) {
+        return LOS_NOK;
+    }
+
+    return LOS_OK;
+}
+
+STATIC VOID OsMemPoolHeadCheck(const struct OsMemPoolHead *pool)
+{
+    struct OsMemFreeNodeHead *tmpNode = NULL;
+    UINT32 index;
+    UINT32 flag = 0;
+
+    if ((pool->info.pool != pool) || !OS_MEM_IS_ALIGNED(pool, sizeof(VOID *))) {
+        PRINT_ERR("wrong mem pool addr: %p, func: %s, line: %d\n", pool, __FUNCTION__, __LINE__);
+        return;
+    }
+
+    for (index = 0; index < OS_MEM_FREE_LIST_COUNT; index++) {
+        for (tmpNode = pool->freeList[index]; tmpNode != NULL; tmpNode = tmpNode->next) {
+            if (OsMemFreeListNodeCheck(pool, tmpNode)) {
+                flag = 1;
+                PRINT_ERR("FreeListIndex: %u, node: %p, bNode: %p, prev:%p, next: %p\n",
+                          index, tmpNode, tmpNode->header.ptr.prev, tmpNode->prev, tmpNode->next);
+            }
+        }
+    }
+
+    if (flag) {
+        PRINTK("mem pool info: poolAddr: %p, poolSize: 0x%x\n", pool, pool->info.totalSize);
+#if (LOSCFG_MEM_WATERLINE == 1)
+        PRINTK("mem pool info: poolWaterLine: 0x%x, poolCurUsedSize: 0x%x\n", pool->info.waterLine,
+               pool->info.curUsedSize);
+#endif
+#if OS_MEM_EXPAND_ENABLE
+        UINT32 size;
+        struct OsMemNodeHead *node = NULL;
+        struct OsMemNodeHead *sentinel = OS_MEM_END_NODE(pool, pool->info.totalSize);
+        while (OsMemIsLastSentinelNode(sentinel) == FALSE) {
+            size = OS_MEM_NODE_GET_SIZE(sentinel->sizeAndFlag);
+            node = OsMemSentinelNodeGet(sentinel);
+            sentinel = OS_MEM_END_NODE(node, size);
+            PRINTK("expand node info: nodeAddr: 0x%x, nodeSize: 0x%x\n", node, size);
+        }
+#endif
+    }
+}
+
+STATIC UINT32 OsMemIntegrityCheck(const struct OsMemPoolHead *pool, struct OsMemNodeHead **tmpNode,
+                struct OsMemNodeHead **preNode)
+{
+    struct OsMemNodeHead *endNode = OS_MEM_END_NODE(pool, pool->info.totalSize);
+
+    OsMemPoolHeadCheck(pool);
+
+    *preNode = OS_MEM_FIRST_NODE(pool);
+    do {
+        for (*tmpNode = *preNode; *tmpNode < endNode; *tmpNode = OS_MEM_NEXT_NODE(*tmpNode)) {
+            if (OS_MEM_IS_GAP_NODE(*tmpNode)) {
+                continue;
+            }
+            if (OsMemIntegrityCheckSub(tmpNode, pool, endNode) == LOS_NOK) {
+                return LOS_NOK;
+            }
+            *preNode = *tmpNode;
+        }
+#if OS_MEM_EXPAND_ENABLE
+        if (OsMemIsLastSentinelNode(*tmpNode) == FALSE) {
+            *preNode = OsMemSentinelNodeGet(*tmpNode);
+            endNode = OS_MEM_END_NODE(*preNode, OS_MEM_NODE_GET_SIZE((*tmpNode)->sizeAndFlag));
+        } else
+#endif
+        {
+            break;
+        }
+    } while (1);
+    return LOS_OK;
+}
+
+#if (LOSCFG_KERNEL_PRINTF != 0)
+STATIC VOID OsMemNodeInfo(const struct OsMemNodeHead *tmpNode,
+                          const struct OsMemNodeHead *preNode)
+{
+    struct OsMemUsedNodeHead *usedNode = NULL;
+    struct OsMemFreeNodeHead *freeNode = NULL;
+
+    if (tmpNode == preNode) {
+        PRINTK("\n the broken node is the first node\n");
+    }
+
+    if (OS_MEM_NODE_GET_USED_FLAG(tmpNode->sizeAndFlag)) {
+        usedNode = (struct OsMemUsedNodeHead *)tmpNode;
+        PRINTK("\n broken node head: %p  "
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            "0x%x  "
+#endif
+            "0x%x, ",
+            usedNode->header.ptr.prev,
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            usedNode->header.magic,
+#endif
+            usedNode->header.sizeAndFlag);
+    } else {
+        freeNode = (struct OsMemFreeNodeHead *)tmpNode;
+        PRINTK("\n broken node head: %p  %p  %p  "
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            "0x%x  "
+#endif
+            "0x%x, ",
+            freeNode->header.ptr.prev, freeNode->next, freeNode->prev,
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            freeNode->header.magic,
+#endif
+            freeNode->header.sizeAndFlag);
+    }
+
+    if (OS_MEM_NODE_GET_USED_FLAG(preNode->sizeAndFlag)) {
+        usedNode = (struct OsMemUsedNodeHead *)preNode;
+        PRINTK("prev node head: %p  "
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            "0x%x  "
+#endif
+            "0x%x\n",
+            usedNode->header.ptr.prev,
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            usedNode->header.magic,
+#endif
+            usedNode->header.sizeAndFlag);
+    } else {
+        freeNode = (struct OsMemFreeNodeHead *)preNode;
+        PRINTK("prev node head: %p  %p  %p  "
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            "0x%x  "
+#endif
+            "0x%x, ",
+            freeNode->header.ptr.prev, freeNode->next, freeNode->prev,
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+            freeNode->header.magic,
+#endif
+            freeNode->header.sizeAndFlag);
+    }
+
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+    OsMemNodeBacktraceInfo(tmpNode, preNode);
+#endif
+}
+#endif
+
+struct OsMemIntegrityCheckInfo {
+    struct OsMemNodeHead preNode;
+    struct OsMemNodeHead errNode;
+};
+
+struct OsMemIntegrityCheckInfo g_integrityCheckRecord = {0};
+
+STATIC INLINE VOID OsMemCheckInfoRecord(const struct OsMemNodeHead *errNode,
+                                     const struct OsMemNodeHead *preNode)
+{
+    (VOID)memcpy(&g_integrityCheckRecord.preNode,
+                   preNode, sizeof(struct OsMemNodeHead));
+    (VOID)memcpy(&g_integrityCheckRecord.errNode,
+                   errNode, sizeof(struct OsMemNodeHead));
+}
+
+STATIC VOID OsMemIntegrityCheckError(struct OsMemPoolHead *pool,
+                                     const struct OsMemNodeHead *tmpNode,
+                                     const struct OsMemNodeHead *preNode,
+                                     UINT32 intSave)
+{
+#if (LOSCFG_KERNEL_PRINTF != 0)
+    OsMemNodeInfo(tmpNode, preNode);
+#endif
+    OsMemCheckInfoRecord(tmpNode, preNode);
+#if (LOSCFG_MEM_FREE_BY_TASKID == 1 || LOSCFG_TASK_MEM_USED == 1)
+    LosTaskCB *taskCB = NULL;
+    if (OS_MEM_NODE_GET_USED_FLAG(preNode->sizeAndFlag)) {
+        struct OsMemUsedNodeHead *usedNode = (struct OsMemUsedNodeHead *)preNode;
+        UINT32 taskID = usedNode->header.taskID;
+        if (taskID >= LOSCFG_BASE_CORE_TSK_LIMIT) {
+            MEM_UNLOCK(pool, intSave);
+            LOS_Panic("Task ID %u in pre node is invalid!\n", taskID);
+            return;
+        }
+
+        taskCB = OS_TCB_FROM_TID(taskID);
+        if ((taskCB->taskStatus & OS_TASK_STATUS_UNUSED) || (taskCB->taskEntry == NULL)) {
+            MEM_UNLOCK(pool, intSave);
+            LOS_Panic("\r\nTask ID %u in pre node is not created!\n", taskID);
+            return;
+        }
+    } else {
+        PRINTK("The prev node is free\n");
+    }
+    MEM_UNLOCK(pool, intSave);
+    PRINT_ERR("cur node: 0x%x, pre node: 0x%x, pre node was allocated by task: %u, %s\n",
+              (UINTPTR)tmpNode, (UINTPTR)preNode, taskCB->taskID, taskCB->taskName);
+    LOS_Panic("Memory integrity check error!\n");
+#else
+    MEM_UNLOCK(pool, intSave);
+    LOS_Panic("Memory integrity check error, cur node: 0x%x, pre node: 0x%x\n", tmpNode, preNode);
+#endif
+}
+
+#if (LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK == 1)
+STATIC INLINE UINT32 OsMemAllocCheck(struct OsMemPoolHead *pool, UINT32 intSave)
+{
+    struct OsMemNodeHead *tmpNode = NULL;
+    struct OsMemNodeHead *preNode = NULL;
+
+    if (OsMemIntegrityCheck(pool, &tmpNode, &preNode)) {
+        OsMemIntegrityCheckError(pool, tmpNode, preNode, intSave);
+        return LOS_NOK;
+    }
+    return LOS_OK;
+}
+#endif
+
+UINT32 LOS_MemIntegrityCheck(const VOID *pool)
+{
+    if (pool == NULL) {
+        return LOS_NOK;
+    }
+
+    struct OsMemPoolHead *poolHead = (struct OsMemPoolHead *)pool;
+    struct OsMemNodeHead *tmpNode = NULL;
+    struct OsMemNodeHead *preNode = NULL;
+    UINT32 intSave = 0;
+
+    MEM_LOCK(poolHead, intSave);
+    if (OsMemIntegrityCheck(poolHead, &tmpNode, &preNode)) {
+        goto ERROR_OUT;
+    }
+    MEM_UNLOCK(poolHead, intSave);
+    return LOS_OK;
+
+ERROR_OUT:
+    OsMemIntegrityCheckError(poolHead, tmpNode, preNode, intSave);
+    return LOS_NOK;
+}
+
+UINT32 LOS_MemFreeNodeShow(VOID *pool)
+{
+#if (LOSCFG_KERNEL_PRINTF != 0)
+    struct OsMemPoolHead *poolInfo = (struct OsMemPoolHead *)pool;
+
+    if ((poolInfo == NULL) || ((UINTPTR)pool != (UINTPTR)poolInfo->info.pool)) {
+        PRINT_ERR("wrong mem pool addr: 0x%x, line: %d\n", (UINTPTR)poolInfo, __LINE__);
+        return LOS_NOK;
+    }
+
+    struct OsMemFreeNodeHead *node = NULL;
+    UINT32 countNum[OS_MEM_FREE_LIST_COUNT] = {0};
+    UINT32 index;
+    UINT32 intSave = 0;
+
+    MEM_LOCK(poolInfo, intSave);
+    for (index = 0; index < OS_MEM_FREE_LIST_COUNT; index++) {
+        node = poolInfo->freeList[index];
+        while (node) {
+            node = node->next;
+            countNum[index]++;
+        }
+    }
+    MEM_UNLOCK(poolInfo, intSave);
+
+    PRINTK("\n   ************************ left free node number**********************\n");
+    for (index = 0; index < OS_MEM_FREE_LIST_COUNT; index++) {
+        if (countNum[index] == 0) {
+            continue;
+        }
+
+        PRINTK("free index: %03u, ", index);
+        if (index < OS_MEM_SMALL_BUCKET_COUNT) {
+            PRINTK("size: [0x%x], num: %u\n", (index + 1) << 2, countNum[index]); /* 2: setup is 4. */
+        } else {
+            UINT32 val = 1 << (((index - OS_MEM_SMALL_BUCKET_COUNT) >> OS_MEM_SLI) + OS_MEM_LARGE_START_BUCKET);
+            UINT32 offset = val >> OS_MEM_SLI;
+            PRINTK("size: [0x%x, 0x%x], num: %u\n",
+                   (offset * ((index - OS_MEM_SMALL_BUCKET_COUNT) % (1 << OS_MEM_SLI))) + val,
+                   ((offset * (((index - OS_MEM_SMALL_BUCKET_COUNT) % (1 << OS_MEM_SLI)) + 1)) + val - 1),
+                   countNum[index]);
+        }
+    }
+    PRINTK("\n   ********************************************************************\n\n");
+#endif
+    return LOS_OK;
+}
+
+VOID LOS_MemUnlockEnable(VOID *pool)
+{
+    if (pool == NULL) {
+        return;
+    }
+
+    ((struct OsMemPoolHead *)pool)->info.attr |= OS_MEM_POOL_UNLOCK_ENABLE;
+}
+
+#if (LOSCFG_MEM_MUL_REGIONS == 1)
+STATIC INLINE UINT32 OsMemMulRegionsParamCheck(VOID *pool, const LosMemRegion * const memRegions,
+                                                UINT32 memRegionCount)
+{
+    const LosMemRegion *memRegion = NULL;
+    VOID *lastStartAddress = NULL;
+    VOID *curStartAddress = NULL;
+    UINT32 lastLength;
+    UINT32 curLength;
+    UINT32 regionCount;
+
+    if ((pool != NULL) && (((struct OsMemPoolHead *)pool)->info.pool != pool)) {
+        PRINT_ERR("wrong mem pool addr: %p, func: %s, line: %d\n", pool, __FUNCTION__, __LINE__);
+        return LOS_NOK;
+    }
+
+    if (pool != NULL) {
+        lastStartAddress = pool;
+        lastLength = ((struct OsMemPoolHead *)pool)->info.totalSize;
+    }
+
+    memRegion = memRegions;
+    regionCount = 0;
+    while (regionCount < memRegionCount) {
+        curStartAddress = memRegion->startAddress;
+        curLength = memRegion->length;
+        if ((curStartAddress == NULL) || (curLength == 0)) {
+            PRINT_ERR("Memory address or length configured wrongly:address:0x%x, the length:0x%x\n",
+                      (UINTPTR)curStartAddress, curLength);
+            return LOS_NOK;
+        }
+        if (((UINTPTR)curStartAddress & (OS_MEM_ALIGN_SIZE - 1)) || (curLength & (OS_MEM_ALIGN_SIZE - 1))) {
+            PRINT_ERR("Memory address or length configured not aligned:address:0x%x, the length:0x%x, alignsize:%d\n",
+                      (UINTPTR)curStartAddress, curLength, OS_MEM_ALIGN_SIZE);
+            return LOS_NOK;
+        }
+        if ((lastStartAddress != NULL) && (((UINT8 *)lastStartAddress + lastLength) >= (UINT8 *)curStartAddress)) {
+            PRINT_ERR("Memory regions overlapped, the last start address:0x%x, "
+                      "the length:0x%x, the current start address:0x%x\n",
+                      (UINTPTR)lastStartAddress, lastLength, (UINTPTR)curStartAddress);
+            return LOS_NOK;
+        }
+        memRegion++;
+        regionCount++;
+        lastStartAddress = curStartAddress;
+        lastLength = curLength;
+    }
+    return LOS_OK;
+}
+
+STATIC INLINE VOID OsMemMulRegionsLink(struct OsMemPoolHead *poolHead, VOID *lastStartAddress, UINT32 lastLength,
+                                       struct OsMemNodeHead *lastEndNode, const LosMemRegion *memRegion)
+{
+    UINT32 curLength;
+    UINT32 gapSize;
+    struct OsMemNodeHead *curEndNode = NULL;
+    struct OsMemNodeHead *curFreeNode = NULL;
+    VOID *curStartAddress = NULL;
+
+    curStartAddress = memRegion->startAddress;
+    curLength = memRegion->length;
+
+    // mark the gap between two regions as one used node
+    gapSize = (UINT8 *)(curStartAddress) - ((UINT8 *)(lastStartAddress) + lastLength);
+    lastEndNode->sizeAndFlag = gapSize + OS_MEM_NODE_HEAD_SIZE;
+    OS_MEM_SET_MAGIC(lastEndNode);
+    OS_MEM_NODE_SET_USED_FLAG(lastEndNode->sizeAndFlag);
+
+    // mark the gap node with magic number
+    OS_MEM_MARK_GAP_NODE(lastEndNode);
+
+    poolHead->info.totalSize += (curLength + gapSize);
+    poolHead->info.totalGapSize += gapSize;
+
+    curFreeNode = (struct OsMemNodeHead *)curStartAddress;
+    curFreeNode->sizeAndFlag = curLength - OS_MEM_NODE_HEAD_SIZE;
+    curFreeNode->ptr.prev = lastEndNode;
+    OS_MEM_SET_MAGIC(curFreeNode);
+    OsMemFreeNodeAdd(poolHead, (struct OsMemFreeNodeHead *)curFreeNode);
+
+    curEndNode = OS_MEM_END_NODE(curStartAddress, curLength);
+    curEndNode->sizeAndFlag = 0;
+    curEndNode->ptr.prev = curFreeNode;
+    OS_MEM_SET_MAGIC(curEndNode);
+    OS_MEM_NODE_SET_USED_FLAG(curEndNode->sizeAndFlag);
+
+#if (LOSCFG_MEM_WATERLINE == 1)
+    poolHead->info.curUsedSize += OS_MEM_NODE_HEAD_SIZE;
+    poolHead->info.waterLine = poolHead->info.curUsedSize;
+#endif
+}
+
+UINT32 LOS_MemRegionsAdd(VOID *pool, const LosMemRegion *const memRegions, UINT32 memRegionCount)
+{
+    UINT32 ret;
+    UINT32 lastLength;
+    UINT32 curLength;
+    UINT32 regionCount;
+    struct OsMemPoolHead *poolHead = NULL;
+    struct OsMemNodeHead *lastEndNode = NULL;
+    struct OsMemNodeHead *firstFreeNode = NULL;
+    const LosMemRegion *memRegion = NULL;
+    VOID *lastStartAddress = NULL;
+    VOID *curStartAddress = NULL;
+
+    ret = OsMemMulRegionsParamCheck(pool, memRegions, memRegionCount);
+    if (ret != LOS_OK) {
+        return ret;
+    }
+
+    memRegion = memRegions;
+    regionCount = 0;
+    if (pool != NULL) { // add the memory regions to the specified memory pool
+        poolHead = (struct OsMemPoolHead *)pool;
+        lastStartAddress = pool;
+        lastLength = poolHead->info.totalSize;
+    } else { // initialize the memory pool with the first memory region
+        lastStartAddress = memRegion->startAddress;
+        lastLength = memRegion->length;
+        poolHead = (struct OsMemPoolHead *)lastStartAddress;
+        ret = LOS_MemInit(lastStartAddress, lastLength);
+        if (ret != LOS_OK) {
+            return ret;
+        }
+        memRegion++;
+        regionCount++;
+    }
+
+    firstFreeNode = OS_MEM_FIRST_NODE(lastStartAddress);
+    lastEndNode = OS_MEM_END_NODE(lastStartAddress, lastLength);
+    /* traverse the rest memory regions, and initialize them as free nodes and link together */
+    while (regionCount < memRegionCount) {
+        curStartAddress = memRegion->startAddress;
+        curLength = memRegion->length;
+
+        OsMemMulRegionsLink(poolHead, lastStartAddress, lastLength, lastEndNode, memRegion);
+        lastStartAddress = curStartAddress;
+        lastLength = curLength;
+        lastEndNode = OS_MEM_END_NODE(curStartAddress, curLength);
+        memRegion++;
+        regionCount++;
+    }
+
+    firstFreeNode->ptr.prev = lastEndNode;
+    return ret;
+}
+#endif
+
+UINT32 OsMemSystemInit(VOID)
+{
+    UINT32 ret;
+
+#if (LOSCFG_SYS_EXTERNAL_HEAP == 0)
+    m_aucSysMem0 = g_memStart;
+#else
+    m_aucSysMem0 = LOSCFG_SYS_HEAP_ADDR;
+#endif
+
+    ret = LOS_MemInit(m_aucSysMem0, LOSCFG_SYS_HEAP_SIZE);
+    PRINT_INFO("LiteOS heap memory address:%p, size:0x%lx\n", m_aucSysMem0, LOSCFG_SYS_HEAP_SIZE);
+    return ret;
+}
+
+#if (LOSCFG_PLATFORM_EXC == 1)
+STATIC VOID OsMemExcInfoGetSub(struct OsMemPoolHead *pool, MemInfoCB *memExcInfo)
+{
+    struct OsMemNodeHead *tmpNode = NULL;
+    UINT32 taskID = OS_TASK_ERRORID;
+    UINT32 intSave = 0;
+
+    (VOID)memset(memExcInfo, 0, sizeof(MemInfoCB));
+
+    MEM_LOCK(pool, intSave);
+    memExcInfo->type = MEM_MANG_MEMORY;
+    memExcInfo->startAddr = (UINTPTR)pool->info.pool;
+    memExcInfo->size = pool->info.totalSize;
+    memExcInfo->free = pool->info.totalSize - pool->info.curUsedSize;
+
+    struct OsMemNodeHead *firstNode = OS_MEM_FIRST_NODE(pool);
+    struct OsMemNodeHead *endNode = OS_MEM_END_NODE(pool, pool->info.totalSize);
+
+    for (tmpNode = firstNode; tmpNode < endNode; tmpNode = OS_MEM_NEXT_NODE(tmpNode)) {
+        memExcInfo->blockSize++;
+        if (OS_MEM_NODE_GET_USED_FLAG(tmpNode->sizeAndFlag)) {
+            if (!OS_MEM_MAGIC_VALID(tmpNode) ||
+                !OsMemAddrValidCheck(pool, tmpNode->ptr.prev)) {
+#if (LOSCFG_MEM_FREE_BY_TASKID == 1 || LOSCFG_TASK_MEM_USED == 1)
+                taskID = ((struct OsMemUsedNodeHead *)tmpNode)->header.taskID;
+#endif
+                goto ERROUT;
+            }
+        } else { /* is free node, check free node range */
+            struct OsMemFreeNodeHead *freeNode = (struct OsMemFreeNodeHead *)tmpNode;
+            if (OsMemAddrValidCheckPrint(pool, &freeNode)) {
+                goto ERROUT;
+            }
+        }
+    }
+    MEM_UNLOCK(pool, intSave);
+    return;
+
+ERROUT:
+    memExcInfo->errorAddr = (UINTPTR)((CHAR *)tmpNode + OS_MEM_NODE_HEAD_SIZE);
+    memExcInfo->errorLen = OS_MEM_NODE_GET_SIZE(tmpNode->sizeAndFlag) - OS_MEM_NODE_HEAD_SIZE;
+    memExcInfo->errorOwner = taskID;
+    MEM_UNLOCK(pool, intSave);
+    return;
+}
+
+UINT32 OsMemExcInfoGet(UINT32 memNumMax, MemInfoCB *memExcInfo)
+{
+    UINT8 *buffer = (UINT8 *)memExcInfo;
+    UINT32 count = 0;
+
+#if (LOSCFG_MEM_MUL_POOL == 1)
+    struct OsMemPoolHead *memPool = g_poolHead;
+    while (memPool != NULL) {
+        OsMemExcInfoGetSub(memPool, (MemInfoCB *)buffer);
+        count++;
+        buffer += sizeof(MemInfoCB);
+        if (count >= memNumMax) {
+            break;
+        }
+        memPool = memPool->nextPool;
+    }
+#else
+    OsMemExcInfoGetSub(m_aucSysMem0, buffer);
+    count++;
+#endif
+
+    return count;
+}
+#endif

--- a/lib/app/include/los_config.h
+++ b/lib/app/include/los_config.h
@@ -1,0 +1,822 @@
+/*
+ * Copyright (c) 2013-2019 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020-2021 Huawei Device Co., Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @defgroup los_config System configuration items
+ * @ingroup kernel
+ */
+
+#ifndef _LOS_CONFIG_H
+#define _LOS_CONFIG_H
+
+#include "target_config.h"
+#include "los_compiler.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+/* =============================================================================
+                                        System clock module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * System clock (unit: HZ)
+ */
+#ifndef OS_SYS_CLOCK
+    #error "OS_SYS_CLOCK is system clock rate which should be defined in target_config.h"
+#endif
+
+/**
+ * @ingroup los_config
+ * Number of Ticks in one second
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_PER_SECOND
+#define LOSCFG_BASE_CORE_TICK_PER_SECOND                    (100UL)
+#endif
+
+/**
+ * @ingroup los_config
+ * Minimum response error accuracy of tick interrupts, number of ticks in one second.
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_PER_SECOND_MINI
+#define LOSCFG_BASE_CORE_TICK_PER_SECOND_MINI               (1000UL) /* 1ms */
+#endif
+
+#if (LOSCFG_BASE_CORE_TICK_PER_SECOND > LOSCFG_BASE_CORE_TICK_PER_SECOND_MINI)
+    #error "LOSCFG_BASE_CORE_TICK_PER_SECOND_MINI must be greater than LOSCFG_BASE_CORE_TICK_PER_SECOND"
+#endif
+
+#if (LOSCFG_BASE_CORE_TICK_PER_SECOND_MINI > 1000UL)
+    #error "LOSCFG_BASE_CORE_TICK_PER_SECOND_MINI must be less than or equal to 1000"
+#endif
+
+#if defined(LOSCFG_BASE_CORE_TICK_PER_SECOND) && \
+    ((LOSCFG_BASE_CORE_TICK_PER_SECOND < 1UL) || (LOSCFG_BASE_CORE_TICK_PER_SECOND > 1000000000UL))
+    #error "LOSCFG_BASE_CORE_TICK_PER_SECOND SHOULD big than 0, and less than 1000000000UL"
+#endif
+
+
+#if (LOSCFG_BASE_CORE_TICK_PER_SECOND <= 1000UL)
+/**
+ * @ingroup los_config
+ * How much time one tick spent (unit:ms)
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_PERIOD_MS
+#define LOSCFG_BASE_CORE_TICK_PERIOD_MS                     (1000UL / LOSCFG_BASE_CORE_TICK_PER_SECOND)
+#endif
+
+#elif (LOSCFG_BASE_CORE_TICK_PER_SECOND <= 1000000UL)
+/**
+ * @ingroup los_config
+ * How much time one tick spent (unit:us)
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_PERIOD_US
+#define LOSCFG_BASE_CORE_TICK_PERIOD_US                     (1000000UL / LOSCFG_BASE_CORE_TICK_PER_SECOND)
+#endif
+
+#else
+/**
+ * @ingroup los_config
+ * How much time one tick spent (unit:ns)
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_PERIOD_NS
+#define LOSCFG_BASE_CORE_TICK_PERIOD_NS                     (1000000000UL / LOSCFG_BASE_CORE_TICK_PER_SECOND)
+#endif
+#endif
+
+#ifndef LOSCFG_BASE_CORE_TICK_HW_TIME
+#define LOSCFG_BASE_CORE_TICK_HW_TIME                       0
+#endif
+
+/**
+ * @ingroup los_config
+ * System timer is a 64/128 bit timer
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_WTIMER
+#define LOSCFG_BASE_CORE_TICK_WTIMER                        0
+#endif
+
+/**
+ * @ingroup los_config
+ * System timer count maximum
+ */
+#ifndef LOSCFG_BASE_CORE_TICK_RESPONSE_MAX
+#define LOSCFG_BASE_CORE_TICK_RESPONSE_MAX                       0
+#endif
+
+/* =============================================================================
+                                        Hardware interrupt module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for hardware interrupt tailoring
+ */
+#ifndef LOSCFG_PLATFORM_HWI
+#define LOSCFG_PLATFORM_HWI                                 1
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for using system defined vector base address and interrupt handlers.
+ * If LOSCFG_USE_SYSTEM_DEFINED_INTERRUPT is set to 0, vector base address will not be
+ * modified by system. In arm, it should be noted that PendSV_Handler and SysTick_Handler should
+ * be redefined to HalPendSV and OsTickHandler respectly in this case, because system depends on
+ * these interrupt handlers to run normally. What's more, LOS_HwiCreate will not register handler.
+ */
+#ifndef LOSCFG_USE_SYSTEM_DEFINED_INTERRUPT
+#define LOSCFG_USE_SYSTEM_DEFINED_INTERRUPT                 1
+#endif
+
+#if (LOSCFG_USE_SYSTEM_DEFINED_INTERRUPT == 1)
+    #if (LOSCFG_PLATFORM_HWI == 0)
+        #error "if LOSCFG_USE_SYSTEM_DEFINED_INTERRUPT is set to 1, then LOSCFG_PLATFORM_HWI must also be set to 1"
+    #endif
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum number of used hardware interrupts, including Tick timer interrupts.
+ */
+#ifndef LOSCFG_PLATFORM_HWI_LIMIT
+#define LOSCFG_PLATFORM_HWI_LIMIT                           32
+#endif
+
+/* =============================================================================
+                                       Task module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Minimum stack size.
+ *
+ * 0x80 bytes, aligned on a boundary of 8.
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_MIN_STACK_SIZE
+#define LOSCFG_BASE_CORE_TSK_MIN_STACK_SIZE                 (ALIGN(0x80, 4))
+#endif
+
+/**
+ * @ingroup los_config
+ * Default task priority
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_DEFAULT_PRIO
+#define LOSCFG_BASE_CORE_TSK_DEFAULT_PRIO                   10
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of tasks except the idle task rather than the number of usable tasks
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_LIMIT
+#define LOSCFG_BASE_CORE_TSK_LIMIT                          5
+#endif
+
+/**
+ * @ingroup los_config
+ * Size of the idle task stack
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_IDLE_STACK_SIZE
+#define LOSCFG_BASE_CORE_TSK_IDLE_STACK_SIZE                0x180UL
+#endif
+
+/**
+ * @ingroup los_config
+ * Default task stack size
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_DEFAULT_STACK_SIZE
+#define LOSCFG_BASE_CORE_TSK_DEFAULT_STACK_SIZE             0x400UL
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for task Robin tailoring
+ */
+#ifndef LOSCFG_BASE_CORE_TIMESLICE
+#define LOSCFG_BASE_CORE_TIMESLICE                         1
+#endif
+
+/**
+ * @ingroup los_config
+ * Longest execution time of tasks with the same priorities
+ */
+#ifndef LOSCFG_BASE_CORE_TIMESLICE_TIMEOUT
+#define LOSCFG_BASE_CORE_TIMESLICE_TIMEOUT                  20000 /* 20ms */
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for task (stack) monitoring module tailoring
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_MONITOR
+#define LOSCFG_BASE_CORE_TSK_MONITOR                        0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for task perf task filter hook
+ */
+#ifndef LOSCFG_BASE_CORE_EXC_TSK_SWITCH
+#define LOSCFG_BASE_CORE_EXC_TSK_SWITCH                     0
+#endif
+
+/*
+ * @ingroup los_config
+ * Configuration item for task context switch hook
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_SWITCH_HOOK
+#define LOSCFG_BASE_CORE_TSK_SWITCH_HOOK()
+#endif
+
+/**
+ * @ingroup los_config
+ * Define a usable task priority.Highest task priority.
+ */
+#ifndef LOS_TASK_PRIORITY_HIGHEST
+#define LOS_TASK_PRIORITY_HIGHEST                           0
+#endif
+
+/**
+ * @ingroup los_config
+ * Define a usable task priority.Lowest task priority.
+ */
+#ifndef LOS_TASK_PRIORITY_LOWEST
+#define LOS_TASK_PRIORITY_LOWEST                            31
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for task stack independent
+ */
+#ifndef LOSCFG_BASE_CORE_TASKSTACK_INDEPENDENT
+#define LOSCFG_BASE_CORE_TASKSTACK_INDEPENDENT              0
+#endif
+
+/**
+ * @ingroup los_config
+ * SP align size
+ */
+#ifndef LOSCFG_STACK_POINT_ALIGN_SIZE
+#define LOSCFG_STACK_POINT_ALIGN_SIZE                       8
+#endif
+
+/* =============================================================================
+                                       Semaphore module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for semaphore module tailoring
+ */
+#ifndef LOSCFG_BASE_IPC_SEM
+#define LOSCFG_BASE_IPC_SEM                                 1
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of semaphores
+ */
+#ifndef LOSCFG_BASE_IPC_SEM_LIMIT
+#define LOSCFG_BASE_IPC_SEM_LIMIT                           6
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum number of semaphores.
+ */
+#ifndef OS_SEM_COUNTING_MAX_COUNT
+#define OS_SEM_COUNTING_MAX_COUNT                           0xFFFF
+#endif
+
+/* =============================================================================
+                                       Mutex module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for mutex module tailoring
+ */
+#ifndef LOSCFG_BASE_IPC_MUX
+#define LOSCFG_BASE_IPC_MUX                                 1
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of mutexes
+ */
+#ifndef LOSCFG_BASE_IPC_MUX_LIMIT
+#define LOSCFG_BASE_IPC_MUX_LIMIT                           6
+#endif
+
+/* =============================================================================
+                                       Queue module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for queue module tailoring
+ */
+#ifndef LOSCFG_BASE_IPC_QUEUE
+#define LOSCFG_BASE_IPC_QUEUE                               1
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of queues rather than the number of usable queues
+ */
+#ifndef LOSCFG_BASE_IPC_QUEUE_LIMIT
+#define LOSCFG_BASE_IPC_QUEUE_LIMIT                         6
+#endif
+
+
+/* =============================================================================
+                                       Software timer module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for software timer module tailoring
+ */
+#ifndef LOSCFG_BASE_CORE_SWTMR
+#define LOSCFG_BASE_CORE_SWTMR                              1
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of software timers rather than the number of usable software timers
+ */
+#ifndef LOSCFG_BASE_CORE_SWTMR_LIMIT
+#define LOSCFG_BASE_CORE_SWTMR_LIMIT                        5
+#endif
+
+/**
+ * @ingroup los_config
+ * Software timer task stack size
+ */
+#ifndef LOSCFG_BASE_CORE_TSK_SWTMR_STACK_SIZE
+#define LOSCFG_BASE_CORE_TSK_SWTMR_STACK_SIZE               LOSCFG_BASE_CORE_TSK_DEFAULT_STACK_SIZE
+#endif
+
+/**
+ * @ingroup los_config
+ * Configurate item for software timer align tailoring
+ */
+#ifndef LOSCFG_BASE_CORE_SWTMR_ALIGN
+#define LOSCFG_BASE_CORE_SWTMR_ALIGN                        0
+#endif
+
+#if (LOSCFG_BASE_CORE_SWTMR_ALIGN == 1)
+    #if (LOSCFG_BASE_CORE_SWTMR == 0)
+        #error "if LOSCFG_BASE_CORE_SWTMR_ALIGN is set to 1, then LOSCFG_BASE_CORE_SWTMR must also be set to 1"
+    #endif
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum size of a software timer queue
+ */
+#ifndef OS_SWTMR_HANDLE_QUEUE_SIZE
+#define OS_SWTMR_HANDLE_QUEUE_SIZE                          (LOSCFG_BASE_CORE_SWTMR_LIMIT + 0)
+#endif
+
+/**
+ * @ingroup los_config
+ * Minimum divisor of software timer multiple alignment
+ */
+#ifndef LOS_COMMON_DIVISOR
+#define LOS_COMMON_DIVISOR                                  10
+#endif
+
+#if (LOSCFG_BASE_CORE_SWTMR == 1)
+    #if (LOSCFG_BASE_IPC_QUEUE == 0)
+        #error "if LOSCFG_BASE_CORE_SWTMR is set to 1, then LOSCFG_BASE_IPC_QUEUE must also be set to 1"
+    #endif
+#endif
+/* =============================================================================
+                                       Memory module configuration ---- to be refactored
+============================================================================= */
+extern UINT8 *m_aucSysMem0;
+
+/**
+ * @ingroup los_config
+ * Configure whether the kernel uses external heap memory
+ */
+#ifndef LOSCFG_SYS_EXTERNAL_HEAP
+#define LOSCFG_SYS_EXTERNAL_HEAP                            0
+#endif
+
+/**
+ * @ingroup los_config
+ * Starting address of the memory
+ */
+#ifndef LOSCFG_SYS_HEAP_ADDR
+#define LOSCFG_SYS_HEAP_ADDR                                (&m_aucSysMem0[0])
+#endif
+
+/**
+ * @ingroup los_config
+ * Starting address of the task stack
+ */
+#ifndef OS_TASK_STACK_ADDR
+#define OS_TASK_STACK_ADDR                                  LOSCFG_SYS_HEAP_ADDR
+#endif
+
+/**
+ * @ingroup los_config
+ * Memory size
+ */
+#ifndef LOSCFG_SYS_HEAP_SIZE
+#define LOSCFG_SYS_HEAP_SIZE                                0x10000UL
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of more mempry pool checking
+ */
+#ifndef LOSCFG_MEM_MUL_POOL
+#define LOSCFG_MEM_MUL_POOL                                 1
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of memory released by task id
+ */
+#ifndef LOSCFG_MEM_FREE_BY_TASKID
+#define LOSCFG_MEM_FREE_BY_TASKID                           0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of mem node integrity checking
+ */
+#ifndef LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK
+#define LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK                0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration memory leak detection
+ * @attention
+ * Need to enable backtrace module synchronously by configuration LOSCFG_BACKTRACE_TYPE,
+ * and call OSBackTraceInit to complete initialization before the memory pool is initialized.
+ */
+#ifndef LOSCFG_MEM_LEAKCHECK
+#define LOSCFG_MEM_LEAKCHECK                                0
+#endif
+
+#if (LOSCFG_MEM_LEAKCHECK == 1) && (LOSCFG_BACKTRACE_TYPE == 0)
+    #error "if LOSCFG_MEM_LEAKCHECK is set to 1, then LOSCFG_BACKTRACE_TYPE must be set to 1, 2 or 3."
+#endif
+
+/**
+ * @ingroup los_config
+ * The default is 4, which means that the function call stack is recorded from the kernel interface,
+ * such as LOS_MemAlloc/LOS_MemAllocAlign/LOS_MemRealloc/LOS_MemFree. If you want to further ignore
+ * the number of function call layers, you can increase this value appropriately.
+ * @attention
+ * The default is in the IAR tool. Under different compilation environments, this value needs to be adjusted.
+ */
+#ifndef LOSCFG_MEM_OMIT_LR_CNT
+#define LOSCFG_MEM_OMIT_LR_CNT                              4
+#endif
+
+/**
+ * @ingroup los_config
+ * The record number of layers of the function call relationship starting from the number of
+ * ignored layers(LOSCFG_MEM_OMIT_LR_CNT).
+ */
+#ifndef LOSCFG_MEM_RECORD_LR_CNT
+#define LOSCFG_MEM_RECORD_LR_CNT                            3
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration memory leak recorded num
+ */
+#ifndef LOSCFG_MEM_LEAKCHECK_RECORD_MAX_NUM
+#define LOSCFG_MEM_LEAKCHECK_RECORD_MAX_NUM                 1024
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration of memory pool record memory consumption waterline
+ */
+#ifndef LOSCFG_MEM_WATERLINE
+#define LOSCFG_MEM_WATERLINE                                1
+#endif
+
+/**
+ * @ingroup los_config
+ * Number of memory checking blocks
+ */
+#ifndef OS_SYS_MEM_NUM
+#define OS_SYS_MEM_NUM                                      20
+#endif
+
+/**
+ * @ingroup los_config
+ * Size of unaligned memory
+ */
+#ifndef OS_SYS_NOCACHEMEM_SIZE
+#define OS_SYS_NOCACHEMEM_SIZE                              0x0UL
+#endif
+
+/**
+ * @ingroup los_config
+ * Starting address of the unaligned memory
+ */
+#if (OS_SYS_NOCACHEMEM_SIZE > 0)
+#define OS_SYS_NOCACHEMEM_ADDR                              (&g_sysNoCacheMem0[0])
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration of multiple non-continuous memory regions as one memory pool
+ */
+#ifndef LOSCFG_MEM_MUL_REGIONS
+#define LOSCFG_MEM_MUL_REGIONS                              0
+#endif
+
+/* =============================================================================
+                                        Exception module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for exception tailoring
+ */
+#ifndef LOSCFG_PLATFORM_EXC
+#define LOSCFG_PLATFORM_EXC                                 0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration of hardware stack protection
+ */
+#ifndef LOSCFG_EXC_HARDWARE_STACK_PROTECTION
+#define LOSCFG_EXC_HARDWARE_STACK_PROTECTION                0
+#endif
+
+/* =============================================================================
+                                        CPUP module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for CPU usage tailoring
+ */
+#ifndef LOSCFG_BASE_CORE_CPUP
+#define LOSCFG_BASE_CORE_CPUP                               0
+#endif
+
+/* =============================================================================
+                                       Test module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration test case to open
+ */
+#ifndef LOSCFG_TEST
+#define LOSCFG_TEST                                         0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration CMSIS_OS_VER
+ */
+#ifndef CMSIS_OS_VER
+#define CMSIS_OS_VER                                        2
+#endif
+
+/* =============================================================================
+                                       Fs module configuration
+============================================================================= */
+#ifndef LOSCFG_SUPPORT_FATFS
+#define LOSCFG_SUPPORT_FATFS                                0
+#endif
+
+#ifndef LOSCFG_SUPPORT_LITTLEFS
+#define LOSCFG_SUPPORT_LITTLEFS                             1
+#endif
+
+#ifndef LOSCFG_LFS_MAX_MOUNT_SIZE
+#define LOSCFG_LFS_MAX_MOUNT_SIZE                           3
+#endif
+
+/* =============================================================================
+                                       Trace module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration trace tool
+ */
+#ifndef LOSCFG_DEBUG_HOOK
+#define LOSCFG_DEBUG_HOOK                                   0
+#endif
+
+#if (LOSCFG_DEBUG_HOOK == 1)
+#ifndef LOSCFG_KERNEL_TRACE
+#define LOSCFG_KERNEL_TRACE                                 0
+#endif
+#endif
+
+#if (LOSCFG_KERNEL_TRACE == 1)
+
+#ifndef LOSCFG_TRACE_FRAME_MAX_PARAMS
+#define LOSCFG_TRACE_FRAME_MAX_PARAMS                       3
+#endif
+
+#ifndef LOSCFG_TRACE_FRAME_EVENT_COUNT
+#define LOSCFG_TRACE_FRAME_EVENT_COUNT                      0
+#endif
+
+#ifndef LOSCFG_RECORDER_MODE_OFFLINE
+#define LOSCFG_RECORDER_MODE_OFFLINE                        1
+#endif
+
+#ifndef LOSCFG_RECORDER_MODE_ONLINE
+#define LOSCFG_RECORDER_MODE_ONLINE                         0
+#endif
+
+#if (!(LOSCFG_RECORDER_MODE_OFFLINE ^ LOSCFG_RECORDER_MODE_ONLINE))
+#error One of LOSCFG_RECORDER_MODE_OFFLINE and LOSCFG_RECORDER_MODE_ONLINE should be set to 1 and only.
+#endif
+
+#ifndef LOSCFG_TRACE_CLIENT_INTERACT
+#define LOSCFG_TRACE_CLIENT_INTERACT                        1
+#endif
+
+#ifndef LOSCFG_TRACE_BUFFER_SIZE
+#define LOSCFG_TRACE_BUFFER_SIZE                            2048
+#endif
+
+#ifndef NUM_HAL_INTERRUPT_UART
+#define NUM_HAL_INTERRUPT_UART                              0xff
+#endif
+
+#ifndef OS_TICK_INT_NUM
+#define OS_TICK_INT_NUM                                     0xff
+#endif
+
+#endif
+
+/* =============================================================================
+                                       PM module configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration item for low power frame tailoring
+ */
+#ifndef LOSCFG_KERNEL_PM
+#define LOSCFG_KERNEL_PM                                     1
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for priority of low-power task.
+ */
+#ifndef LOSCFG_KERNEL_PM_TASK_PTIORITY
+#define LOSCFG_KERNEL_PM_TASK_PTIORITY                       1
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for stack size of low-power task.
+ */
+#ifndef LOSCFG_KERNEL_PM_TASK_STACKSIZE
+#define LOSCFG_KERNEL_PM_TASK_STACKSIZE                      0x800
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for low power frame debug tailoring
+ */
+#ifndef LOSCFG_KERNEL_PM_DEBUG
+#define LOSCFG_KERNEL_PM_DEBUG                               0
+#endif
+
+/* =============================================================================
+                                       printf configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration liteos printf
+ */
+#ifndef LOSCFG_KERNEL_PRINTF
+#define LOSCFG_KERNEL_PRINTF                                1
+#endif
+
+/* =============================================================================
+                                       backtrace configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration backtrace type
+ * 0: Close stack analysis module.
+ * 1: Call stack analysis for cortex-m series by scanning the stack.
+ * 2: Call stack analysis for risc-v by using frame pointer.
+ * 3: Call stack analysis for risc-v by scanning the stack.
+ * others: Not currently supported.
+ */
+#ifndef LOSCFG_BACKTRACE_TYPE
+#define LOSCFG_BACKTRACE_TYPE                                0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration backtrace depth.
+ */
+#ifndef LOSCFG_BACKTRACE_DEPTH
+#define LOSCFG_BACKTRACE_DEPTH                               15
+#endif
+
+/* =============================================================================
+                                       trustzone configuration
+============================================================================= */
+/**
+ * @ingroup los_config
+ * Configuration trustzone secure heap size.
+ */
+#ifndef LOSCFG_SECURE_HEAP_SIZE
+#define LOSCFG_SECURE_HEAP_SIZE                              2048
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration trustzone secure stack default size.
+ * The secure stack must be allocated before the task calls non-secure callble functions.
+ */
+#ifndef LOSCFG_SECURE_STACK_DEFAULT_SIZE
+#define LOSCFG_SECURE_STACK_DEFAULT_SIZE                     512
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item for mpu.
+ */
+#ifndef LOSCFG_MPU_ENABLE
+#define LOSCFG_MPU_ENABLE                                    0
+#endif
+
+#if (LOSCFG_EXC_HARDWARE_STACK_PROTECTION == 1) && (LOSCFG_MPU_ENABLE == 0)
+#error "if hardware stack protection is enabled, then MPU should be supported and enabled"
+#endif
+
+/*=============================================================================
+                                       shell module configuration
+=============================================================================*/
+/**
+ * @ingroup los_config
+ * Configuration item for shell.
+ */
+#ifndef LOSCFG_USE_SHELL
+#define LOSCFG_USE_SHELL                                     0
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration shell task priority.
+ */
+#ifndef LOSCFG_SHELL_PRIO
+#define LOSCFG_SHELL_PRIO                                    3
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration item to get task used memory.
+ */
+#ifndef LOSCFG_TASK_MEM_USED
+#define LOSCFG_TASK_MEM_USED                                 0
+#endif
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+
+#endif /* _LOS_CONFIG_H */

--- a/lib/app/include/los_context.h
+++ b/lib/app/include/los_context.h
@@ -1,0 +1,81 @@
+#ifndef _LOS_CONTEXT_H
+#define _LOS_CONTEXT_H
+
+#include "los_compiler.h"
+#include "los_interrupt.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+/**
+ * @ingroup  los_context
+ * @brief: Task stack initialization.
+ *
+ * @par Description:
+ * This API is used to initialize the task stack.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  taskID     [IN] Type#UINT32: TaskID.
+ * @param  stackSize  [IN] Type#UINT32: Total size of the stack.
+ * @param  topStack   [IN] Type#VOID *: Top of task's stack.
+ *
+ * @retval: context Type#TaskContext *.
+ * @par Dependency:
+ * <ul><li>los_context.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern VOID *HalTskStackInit(UINT32 taskID, UINT32 stackSize, VOID *topStack);
+
+/**
+ * @ingroup  los_context
+ * @brief: Function to sys exit.
+ *
+ * @par Description:
+ * This API is used to sys exit.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  None.
+ *
+ * @retval: None.
+ * @par Dependency:
+ * <ul><li>los_context.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+LITE_OS_SEC_TEXT_MINOR NORETURN VOID HalSysExit(VOID);
+
+/**
+ * @ingroup  los_context
+ * @brief: Task scheduling Function.
+ *
+ * @par Description:
+ * This API is used to scheduling task.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  None.
+ *
+ * @retval: None.
+ * @par Dependency:
+ * <ul><li>los_context.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern VOID HalTaskSchedule(VOID);
+
+typedef VOID (*OS_TICK_HANDLER)(VOID);
+UINT32 HalStartSchedule(VOID);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#endif /* _LOS_CONTEXT_H */

--- a/lib/app/include/los_interrupt.h
+++ b/lib/app/include/los_interrupt.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2013-2019 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020-2021 Huawei Device Co., Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LOS_INTERRUPT_H
+#define _LOS_INTERRUPT_H
+#include "los_config.h"
+#include "los_compiler.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+/* *
+ * @ingroup los_interrupt
+ * Configuration item for interrupt with argument
+ */
+#ifndef OS_HWI_WITH_ARG
+#define OS_HWI_WITH_ARG                       0
+#endif
+
+typedef UINT32 HWI_HANDLE_T;
+
+typedef UINT16 HWI_PRIOR_T;
+
+typedef UINT16 HWI_MODE_T;
+
+typedef UINT32 HWI_ARG_T;
+
+#if (OS_HWI_WITH_ARG == 1)
+typedef VOID (*HWI_PROC_FUNC)(VOID *parm);
+#else
+typedef VOID (*HWI_PROC_FUNC)(void);
+#endif
+
+/* stack protector */
+extern UINT32 __stack_chk_guard;
+
+extern VOID __stack_chk_fail(VOID);
+
+UINT32 HalIsIntActive(VOID);
+#define OS_INT_ACTIVE    (HalIsIntActive())
+#define OS_INT_INACTIVE  (!(OS_INT_ACTIVE))
+#define LOS_HwiCreate HalHwiCreate
+#define LOS_HwiDelete HalHwiDelete
+
+UINT32 HalIntLock(VOID);
+#define LOS_IntLock HalIntLock
+
+VOID HalIntRestore(UINT32 intSave);
+#define LOS_IntRestore HalIntRestore
+
+UINT32 HalIntUnLock(VOID);
+#define LOS_IntUnLock HalIntUnLock
+
+/**
+ * @ingroup  los_interrupt
+ * @brief Delete hardware interrupt.
+ *
+ * @par Description:
+ * This API is used to delete hardware interrupt.
+ *
+ * @attention
+ * <ul>
+ * <li>The hardware interrupt module is usable only when the configuration item for hardware interrupt tailoring is enabled.</li>
+ * <li>Hardware interrupt number value range: [OS_USER_HWI_MIN,OS_USER_HWI_MAX]. The value range applicable for a Cortex-A7 platform is [32,95].</li>
+ * <li>OS_HWI_MAX_NUM specifies the maximum number of interrupts that can be created.</li>
+ * <li>Before executing an interrupt on a platform, refer to the chip manual of the platform.</li>
+ * </ul>
+ *
+ * @param  hwiNum   [IN] Type#HWI_HANDLE_T: hardware interrupt number. The value range applicable for a Cortex-A7 platform is [32,95].
+ *
+ * @retval #OS_ERRNO_HWI_NUM_INVALID              0x02000900: Invalid interrupt number.
+ * @retval #LOS_OK                                0         : The interrupt is successfully delete.
+ * @par Dependency:
+ * <ul><li>los_interrupt.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 HalHwiDelete(HWI_HANDLE_T hwiNum);
+
+/**
+ * @ingroup  los_interrupt
+ * @brief Create a hardware interrupt.
+ *
+ * @par Description:
+ * This API is used to configure a hardware interrupt and register a hardware interrupt handling function.
+ *
+ * @attention
+ * <ul>
+ * <li>The hardware interrupt module is usable only when the configuration item for hardware interrupt tailoring is enabled.</li>
+ * <li>Hardware interrupt number value range: [OS_USER_HWI_MIN,OS_USER_HWI_MAX]. The value range applicable for a Cortex-A7 platform is [32,95].</li>
+ * <li>OS_HWI_MAX_NUM specifies the maximum number of interrupts that can be created.</li>
+ * <li>Before executing an interrupt on a platform, refer to the chip manual of the platform.</li>
+ * </ul>
+ *
+ * @param  hwiNum   [IN] Type#HWI_HANDLE_T: hardware interrupt number. The value range applicable for a Cortex-A7 platform is [32,95].
+ * @param  hwiPrio  [IN] Type#HWI_PRIOR_T: hardware interrupt priority. Ignore this parameter temporarily.
+ * @param  mode     [IN] Type#HWI_MODE_T: hardware interrupt mode. Ignore this parameter temporarily.
+ * @param  handler  [IN] Type#HWI_PROC_FUNC: interrupt handler used when a hardware interrupt is triggered.
+ * @param  arg      [IN] Type#HWI_ARG_T: input parameter of the interrupt handler used when a hardware interrupt is triggered.
+ *
+ * @retval #OS_ERRNO_HWI_PROC_FUNC_NULL               0x02000901: Null hardware interrupt handling function.
+ * @retval #OS_ERRNO_HWI_NUM_INVALID                  0x02000900: Invalid interrupt number.
+ * @retval #OS_ERRNO_HWI_NO_MEMORY                    0x02000903: Insufficient memory for hardware interrupt creation.
+ * @retval #OS_ERRNO_HWI_ALREADY_CREATED              0x02000904: The interrupt handler being created has already been created.
+ * @retval #LOS_OK                                    0         : The interrupt is successfully created.
+ * @par Dependency:
+ * <ul><li>los_interrupt.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 HalHwiCreate(HWI_HANDLE_T hwiNum,
+                           HWI_PRIOR_T hwiPrio,
+                           HWI_MODE_T mode,
+                           HWI_PROC_FUNC handler,
+                           HWI_ARG_T arg);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#endif /* _LOS_INTERRUPT_H */

--- a/lib/app/include/los_memory.h
+++ b/lib/app/include/los_memory.h
@@ -1,0 +1,442 @@
+#ifndef _LOS_MEMORY_H
+#define _LOS_MEMORY_H
+
+#include "print.h"
+#include "los_config.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#if (LOSCFG_PLATFORM_EXC == 1)
+UINT32 OsMemExcInfoGet(UINT32 memNumMax, MemInfoCB *memExcInfo);
+#endif
+
+/**
+ * @ingroup los_memory
+ * Starting address of the memory.
+ */
+#define OS_SYS_MEM_ADDR     LOSCFG_SYS_HEAP_ADDR
+
+#if (LOSCFG_MEM_LEAKCHECK == 1)
+/**
+ * @ingroup los_memory
+ * @brief Print function call stack information of all used nodes.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to print function call stack information of all used nodes.</li>
+ * </ul>
+ *
+ * @param pool          [IN] Starting address of memory.
+ *
+ * @retval none.
+ * @par Dependency:
+ * <ul>
+ * <li>los_memory.h: the header file that contains the API declaration.</li>
+ * </ul>
+ * @see None.
+ */
+extern VOID LOS_MemUsedNodeShow(VOID *pool);
+#endif
+
+#if (LOSCFG_MEM_MUL_POOL == 1)
+/**
+ * @ingroup los_memory
+ * @brief Deinitialize dynamic memory.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to deinitialize the dynamic memory of a doubly linked list.</li>
+ * </ul>
+ *
+ * @param pool          [IN] Starting address of memory.
+ *
+ * @retval #OS_ERROR   The dynamic memory fails to be deinitialized.
+ * @retval #LOS_OK     The dynamic memory is successfully deinitialized.
+ * @par Dependency:
+ * <ul>
+ * <li>los_memory.h: the header file that contains the API declaration.</li>
+ * </ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemDeInit(VOID *pool);
+
+/**
+ * @ingroup los_memory
+ * @brief Print infomation about all pools.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to print infomation about all pools.</li>
+ * </ul>
+ *
+ * @retval #UINT32   The pool number.
+ * @par Dependency:
+ * <ul>
+ * <li>los_memory.h: the header file that contains the API declaration.</li>
+ * </ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemPoolList(VOID);
+#endif
+
+#if (LOSCFG_MEM_MUL_REGIONS == 1)
+typedef struct {
+    VOID *startAddress;
+    UINT32 length;
+} LosMemRegion;
+
+/**
+ * @ingroup los_memory
+ * @brief Initialize multiple non-continuous memory regions.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to initialize multiple non-continuous memory regions. If the starting address of a pool is specified,
+ *  the memory regions will be linked to the pool as free nodes. Otherwise, the first memory region will be initialized as a 
+ *  new pool, and the rest regions will be linked as free nodes to the new pool.</li>
+ * </ul>
+ * 
+ * @attention
+ * <ul>
+ * <li>If the starting address of a memory pool is specified, the start address of the non-continuous memory regions should be
+ *  greater than the end address of the memory pool.</li>
+ * <li>The multiple non-continuous memory regions shouldn't conflict with each other.</li>
+ * </ul>
+ *
+ * @param pool           [IN] The memory pool address. If NULL is specified, the start address of first memory region will be 
+ *                            initialized as the memory pool address. If not NULL, it should be a valid address of a memory pool.
+ * @param memRegions     [IN] The LosMemRegion array that contains multiple non-continuous memory regions. The start address
+ *                           of the memory regions are placed in ascending order.
+ * @param memRegionCount [IN] The count of non-continuous memory regions, and it should be the length of the LosMemRegion array.
+ * 
+ * @retval #LOS_NOK    The multiple non-continuous memory regions fails to be initialized.
+ * @retval #LOS_OK     The multiple non-continuous memory regions is initialized successfully.
+ * @par Dependency:
+ * <ul>
+ * <li>los_memory.h: the header file that contains the API declaration.</li>
+ * </ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemRegionsAdd(VOID *pool, const LosMemRegion * const memRegions, UINT32 memRegionCount);
+#endif
+
+/**
+ * @ingroup los_memory
+ * Memory pool extern information structure
+ */
+typedef struct {
+    UINT32 totalUsedSize;
+    UINT32 totalFreeSize;
+    UINT32 maxFreeNodeSize;
+    UINT32 usedNodeNum;
+    UINT32 freeNodeNum;
+#if (LOSCFG_MEM_WATERLINE == 1)
+    UINT32 usageWaterLine;
+#endif
+} LOS_MEM_POOL_STATUS;
+
+/**
+ * @ingroup los_memory
+ * @brief Initialize dynamic memory.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to initialize the dynamic memory of a doubly linked list.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The size parameter value should match the following two conditions :
+ * 1) Be less than or equal to the Memory pool size;
+ * 2) Be greater than the size of OS_MEM_MIN_POOL_SIZE.</li>
+ * <li>Call this API when dynamic memory needs to be initialized during the startup of Huawei LiteOS.</li>
+ * <li>The parameter input must be four byte-aligned.</li>
+ * <li>The init area [pool, pool + size] should not conflict with other pools.</li>
+ * </ul>
+ *
+ * @param pool         [IN] Starting address of memory.
+ * @param size         [IN] Memory size.
+ *
+ * @retval #OS_ERROR   The dynamic memory fails to be initialized.
+ * @retval #LOS_OK     The dynamic memory is successfully initialized.
+ * @par Dependency:
+ * <ul>
+ * <li>los_memory.h: the header file that contains the API declaration.</li>
+ * </ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemInit(VOID *pool, UINT32 size);
+
+/**
+ * @ingroup los_memory
+ * @brief Allocate dynamic memory.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to allocate a memory block of which the size is specified.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * <li>The size of the input parameter size can not be greater than the memory pool size that specified at the second
+ * input parameter of LOS_MemInit.</li>
+ * <li>The size of the input parameter size must be four byte-aligned.</li>
+ * </ul>
+ *
+ * @param  pool    [IN] Pointer to the memory pool that contains the memory block to be allocated.
+ * @param  size    [IN] Size of the memory block to be allocated (unit: byte).
+ *
+ * @retval #NULL          The memory fails to be allocated.
+ * @retval #VOID*         The memory is successfully allocated with the starting address of the allocated memory block
+ *                        returned.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see LOS_MemRealloc | LOS_MemAllocAlign | LOS_MemFree
+ */
+extern VOID *LOS_MemAlloc(VOID *pool, UINT32 size);
+
+/**
+ * @ingroup los_memory
+ * @brief Free dynamic memory.
+ *
+ * @par Description:
+ * <li>This API is used to free specified dynamic memory that has been allocated.</li>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * <li>The input ptr parameter must be allocated by LOS_MemAlloc or LOS_MemAllocAlign or LOS_MemRealloc.</li>
+ * </ul>
+ *
+ * @param  pool  [IN] Pointer to the memory pool that contains the dynamic memory block to be freed.
+ * @param  ptr   [IN] Starting address of the memory block to be freed.
+ *
+ * @retval #LOS_NOK          The memory block fails to be freed because the starting address of the memory block is
+ *                           invalid, or the memory overwriting occurs.
+ * @retval #LOS_OK           The memory block is successfully freed.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see LOS_MemAlloc | LOS_MemRealloc | LOS_MemAllocAlign
+ */
+extern UINT32 LOS_MemFree(VOID *pool, VOID *ptr);
+
+/**
+ * @ingroup los_memory
+ * @brief Re-allocate a memory block.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to allocate a new memory block of which the size is specified by size if the original memory
+ * block size is insufficient. The new memory block will copy the data in the original memory block of which the
+ * address is specified by ptr. The size of the new memory block determines the maximum size of data to be copied.
+ * After the new memory block is created, the original one is freed.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * <li>The input ptr parameter must be allocated by LOS_MemAlloc or LOS_MemAllocAlign.</li>
+ * <li>The size of the input parameter size can not be greater than the memory pool size that specified at the second
+ * input parameter of LOS_MemInit.</li>
+ * <li>The size of the input parameter size must be aligned as follows: 1) if the ptr is allocated by LOS_MemAlloc,
+ * it must be four byte-aligned; 2) if the ptr is allocated by LOS_MemAllocAlign, it must be aligned with the size of
+ * the input parameter boundary of LOS_MemAllocAlign.</li>
+ * </ul>
+ *
+ * @param  pool     [IN] Pointer to the memory pool that contains the original and new memory blocks.
+ * @param  ptr      [IN] Address of the original memory block.
+ * @param  size     [IN] Size of the new memory block.
+ *
+ * @retval #NULL    The memory fails to be re-allocated.
+ * @retval #VOID*   The memory is successfully re-allocated with the starting address of the new memory block returned.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see LOS_MemAlloc | LOS_MemAllocAlign | LOS_MemFree
+ */
+extern VOID *LOS_MemRealloc(VOID *pool, VOID *ptr, UINT32 size);
+
+/**
+ * @ingroup los_memory
+ * @brief Allocate aligned memory.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to allocate memory blocks of specified size and of which the starting addresses are aligned on
+ * a specified boundary.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * <li>The size of the input parameter size can not be greater than the memory pool size that specified at the second
+ * input parameter of LOS_MemInit.</li>
+ * <li>The alignment parameter value must be a power of 2 with the minimum value being 4.</li>
+ * </ul>
+ *
+ * @param  pool      [IN] Pointer to the memory pool that contains the memory blocks to be allocated.
+ * @param  size      [IN] Size of the memory to be allocated.
+ * @param  boundary  [IN] Boundary on which the memory is aligned.
+ *
+ * @retval #NULL    The memory fails to be allocated.
+ * @retval #VOID*   The memory is successfully allocated with the starting address of the allocated memory returned.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see LOS_MemAlloc | LOS_MemRealloc | LOS_MemFree
+ */
+extern VOID *LOS_MemAllocAlign(VOID *pool, UINT32 size, UINT32 boundary);
+
+/**
+ * @ingroup los_memory
+ * @brief Get the size of memory pool's size.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to get the size of memory pool' total size.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * </ul>
+ *
+ * @param  pool           [IN] A pointer pointed to the memory pool.
+ *
+ * @retval #LOS_NOK        The incoming parameter pool is NULL.
+ * @retval #UINT32         The size of the memory pool.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemPoolSizeGet(const VOID *pool);
+
+/**
+ * @ingroup los_memory
+ * @brief Get the size of memory totally used.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to get the size of memory totally used in memory pool.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * </ul>
+ *
+ * @param  pool           [IN] A pointer pointed to the memory pool.
+ *
+ * @retval #LOS_NOK        The incoming parameter pool is NULL.
+ * @retval #UINT32         The size of the memory pool used.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemTotalUsedGet(VOID *pool);
+
+/**
+ * @ingroup los_memory
+ * @brief Get the infomation of memory pool.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to get the infomation of memory pool.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * </ul>
+ *
+ * @param  pool                 [IN] A pointer pointed to the memory pool.
+ * @param  poolStatus           [IN] A pointer for storage the pool status
+ *
+ * @retval #LOS_NOK           The incoming parameter pool is NULL or invalid.
+ * @retval #LOS_OK            Success to get memory infomation.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemInfoGet(VOID *pool, LOS_MEM_POOL_STATUS *poolStatus);
+
+/**
+ * @ingroup los_memory
+ * @brief Get the number of free node in every size.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to get the number of free node in every size.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * </ul>
+ *
+ * @param  pool               [IN] A pointer pointed to the memory pool.
+ *
+ * @retval #LOS_NOK           The incoming parameter pool is NULL.
+ * @retval #UINT32            The address of the last used node that casts to UINT32.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemFreeNodeShow(VOID *pool);
+
+/**
+ * @ingroup los_memory
+ * @brief Check the memory pool integrity.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to check the memory pool integrity.</li>
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The input pool parameter must be initialized via func LOS_MemInit.</li>
+ * <li>LOS_MemIntegrityCheck will be called by malloc function when the macro of LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK
+ * is defined in LiteOS.</li>
+ * <li>LOS_MemIntegrityCheck function can be called by user anytime.</li>
+ * </ul>
+ *
+ * @param  pool              [IN] A pointer pointed to the memory pool.
+ *
+ * @retval #LOS_NOK           The memory pool (pool) is impaired.
+ * @retval #LOS_OK            The memory pool (pool) is integrated.
+ * @par Dependency:
+ * <ul><li>los_memory.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ */
+extern UINT32 LOS_MemIntegrityCheck(const VOID *pool);
+
+/**
+ * @ingroup los_memory
+ * @brief Enable memory pool to support no internal lock during using interfaces.
+ *
+ * @par Description:
+ * <ul>
+ * <li>This API is used to enable memory pool to support no internal lock during using interfaces,</li>
+ * <li>such as LOS_MemAlloc/LOS_MemAllocAlign/LOS_MemRealloc/LOS_MemFree and so on.
+ * </ul>
+ * @attention
+ * <ul>
+ * <li>The memory pool does not support multi-threaded concurrent application scenarios.
+ * <li>If you want to use this function, you need to call this interface before the memory
+ * pool is used, it cannot be called during the trial period.</li>
+ * </ul>
+ *
+ * @param pool         [IN] Starting address of memory.
+ *
+ * @retval node.
+ * @par Dependency:
+ * <ul>
+ * <li>los_memory.h: the header file that contains the API declaration.</li>
+ * </ul>
+ * @see None.
+ */
+extern VOID LOS_MemUnlockEnable(VOID *pool);
+
+extern UINT32 OsMemSystemInit(VOID);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#endif /* _LOS_MEMORY_H */

--- a/lib/app/include/los_task.h
+++ b/lib/app/include/los_task.h
@@ -1,0 +1,15 @@
+#ifndef _LOS_TASK_H
+#define _LOS_TASK_H
+
+#include "los_compiler.h"
+
+/**
+ * @ingroup los_task
+ * Maximum number of tasks.
+ *
+ */
+extern UINT32               g_taskMaxNum;
+
+extern NORETURN VOID LOS_Panic(const CHAR *fmt, ...);
+
+#endif

--- a/lib/app/include/print.h
+++ b/lib/app/include/print.h
@@ -4,5 +4,8 @@
 #include <stdarg.h>
 
 void eapp_print(const char* s, ...);
+
+#define PRINT_ERR(fmt, args...)      eapp_print(fmt, ##args)
+#define PRINT_INFO(fmt, args...)     eapp_print(fmt, ##args)
 #define PRINTK(fmt, args...)         eapp_print(fmt, ##args)
 #endif

--- a/lib/app/include/soc.h
+++ b/lib/app/include/soc.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020-2021 Huawei Device Co., Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _SOC_H
+#define _SOC_H
+#include "soc_common.h"
+
+/*
+ * Get the response interrupt number via mcause.
+ * id = mcause & MCAUSE_INT_ID_MASK
+ */
+#define MCAUSE_INT_ID_MASK                            0x7FFFFFF
+#define MSIP                                          0x2000000
+#define MTIMERCMP                                     0x2004000
+#define MTIMER                                        0x200BFF8
+#define CLOCK_CONTRAL_REG                             0x10008000
+
+/* interrupt base addr : 0xc000000 + 4 * interrupt ID
+ * [2:0]   priority
+ * [31:3]  reserved
+ */
+#define PLIC_PRIO_BASE                                 0xC000000
+#define PLIC_PEND_BASE                                 0xC001000 /* interrupt 0-31 */
+#define PLIC_PEND_REG2                                 0xC001004 /* interrupt 32-52 */.
+#define PLIC_ENABLE_BASE                               0xC002000 /* interrupt 0-31 */
+#define PLIC_ENABLE_REG2                               0xC002004 /* interrupt 32-52 */
+#define PLIC_REG_BASE                                  0xC200000
+
+#define UART0_BASE                                     0x10000000
+
+#define UART0_CLK_FREQ                                 0x32000000
+#define UART0_BAUDRAT                                  115200
+
+#define RISCV_SYS_MAX_IRQ                              11
+#define RISCV_WDOGCMP_IRQ                              (RISCV_SYS_MAX_IRQ + 1)
+#define RISCV_RTCCMP_IRQ                               (RISCV_SYS_MAX_IRQ + 2)
+#define RISCV_UART0_IRQ                                (RISCV_SYS_MAX_IRQ + 3)
+
+#define RISCV_PLIC_VECTOR_CNT                          53
+
+#endif

--- a/lib/app/include/soc_common.h
+++ b/lib/app/include/soc_common.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2013-2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020-2021 Huawei Device Co., Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SOC_COMMON_H
+#define _SOC_COMMON_H
+
+#define LREG ld
+#define SREG sd
+#define REGBYTES 8
+
+#define EXC_SIZE_ON_STACK  (36 * REGBYTES)
+#define INT_SIZE_ON_STACK  (32 * REGBYTES)
+
+/* task TCB offset */
+#define TASK_CB_KERNEL_SP       0x0
+#define TASK_CB_STATUS          0x4
+
+#define UINT32_CUT_MASK         0xFFFFFFFF
+#define UINT8_CUT_MASK          0xFF
+#define OS_MV_32_BIT            32
+
+/************************ sstatus ************************/
+#define RISCV_SSTATUS_UIE                   0x00000001
+#define RISCV_SSTATUS_SIE                   0x00000002
+#define RISCV_SSTATUS_UPIE                  0x00000010
+#define RISCV_SSTATUS_SPIE                  0x00000020
+#define RISCV_SSTATUS_SPP                   0x00000100
+
+/************************ sie ***************************/
+#define RISCV_SIE_USIE                      0x000000001
+#define RISCV_SIE_SSIE                      0x000000002
+#define RISCV_SIE_UTIE                      0x000000010
+#define RISCV_SIE_STIE                      0x000000020
+#define RISCV_SIE_UEIE                      0x000000100
+#define RISCV_SIE_SEIE                      0x000000200
+
+/************************** scause ***********************/
+#ifndef SCAUSE_INT_ID_MASK
+#define SCAUSE_INT_ID_MASK                  0x7FFFFFFFFFFFFFF
+#endif
+#define RISCV_SCAUSE_ECALL_U                8
+
+#define RISCV_USER_SOFT_IRQ                 0
+#define RISCV_SUPE_SOFT_IRQ                 1
+#define RISCV_USER_TIMER_IRQ                4
+#define RISCV_SUPE_TIMER_IRQ                5
+#define RISCV_USER_EXT_IRQ                  8
+#define RISCV_SUPE_EXT_IRQ                  9
+
+
+#define READ_CSR(reg) ({                                          \
+    UINT32 _tmp;                                                  \
+    __asm__ volatile("csrr %0, " #reg : "=r"(_tmp) : : "memory"); \
+    _tmp;                                                         \
+})
+
+#define WRITE_CSR(reg, val) ({                                    \
+    __asm__ volatile("csrw " #reg ", %0" : : "r"(val) : "memory"); \
+})
+
+#define SET_CSR(reg, val) ({                                       \
+    __asm__ volatile("csrs " #reg ", %0" : : "r"(val) : "memory"); \
+})
+
+#define CLEAR_CSR(reg, val) ({                                     \
+    __asm__ volatile("csrc " #reg ", %0" : : "r"(val) : "memory"); \
+})
+
+#define READ_CUSTOM_CSR(reg) ({                                         \
+    UINT32 _tmp;                                                        \
+    __asm__ volatile("csrr %0, %1" : "=r"(_tmp) : "i"(reg) : "memory"); \
+    _tmp;                                                               \
+})
+
+#define WRITE_CUSTOM_CSR(reg, val) ({                             \
+    __asm__ volatile("csrw %0, %1" : : "i"(reg), "r"(val) : "memory"); \
+})
+
+#define SET_CUSTOM_CSR(reg, val) ({                                \
+    __asm__ volatile("csrs " #reg ", %0" : : "r"(val) : "memory"); \
+})
+
+#define CLEAR_CUSTOM_CSR(reg, val) ({                              \
+    __asm__ volatile("csrc " #reg ", %0" : : "r"(val) : "memory"); \
+})
+
+#endif

--- a/lib/app/include/target_config.h
+++ b/lib/app/include/target_config.h
@@ -1,0 +1,57 @@
+#ifndef _TARGETS_CONFIG_H
+#define _TARGETS_CONFIG_H
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#define OS_SYS_CLOCK                                  10000000UL
+
+#define LOSCFG_BASE_CORE_TICK_PER_SECOND              1000
+
+/****************************** System clock module configuration ****************************/
+#define LOSCFG_BASE_CORE_TIMER_NUM                      7
+
+/****************************** Task module configuration ********************************/
+#define LOSCFG_BASE_CORE_TSK_LIMIT                      20            // max num task
+#define LOSCFG_BASE_CORE_TSK_IDLE_STACK_SIZE            (0x500U)      // IDLE task stack
+#define LOSCFG_BASE_CORE_TSK_DEFAULT_STACK_SIZE         (0x2D0U)      // default stack
+#define LOSCFG_BASE_CORE_TSK_MIN_STACK_SIZE             (0x130U)
+#define LOSCFG_BASE_CORE_TIMESLICE                      1             // task-ROBIN moduel cutting switch
+#define LOSCFG_BASE_CORE_TIMESLICE_TIMEOUT              10
+/****************************** Semaphore module configuration ******************************/
+#define LOSCFG_BASE_IPC_SEM                             0
+#define LOSCFG_BASE_IPC_SEM_LIMIT                       10              // the max sem-numb
+/****************************** mutex module configuration ******************************/
+#define LOSCFG_BASE_IPC_MUX                             0
+#define LOSCFG_BASE_IPC_MUX_LIMIT                       10              // the max mutex-num
+/****************************** Queue module configuration ********************************/
+#define LOSCFG_BASE_IPC_QUEUE                           0
+#define LOSCFG_BASE_IPC_QUEUE_LIMIT                     10              //the max queue-numb
+
+/****************************** Software timer module configuration **************************/
+#define LOSCFG_BASE_CORE_SWTMR                          0
+#define LOSCFG_BASE_CORE_SWTMR_LIMIT                    10				// the max SWTMR numb
+
+/****************************** Memory module configuration **************************/
+#define LOSCFG_MEM_MUL_POOL                             0
+#define OS_SYS_MEM_NUM                                  20
+/*=============================================================================
+                                       Exception module configuration
+=============================================================================*/
+#define LOSCFG_PLATFORM_EXC                             0
+/* =============================================================================
+                                       printf module configuration
+============================================================================= */
+#define LOSCFG_KERNEL_PRINTF                            1
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+
+#endif /* _TARGETS_CONFIG_H */


### PR DESCRIPTION
`los_memory.c` and `los_memory.h` are fully ported with some changes:

- Remove some debug functions
- Change secure mem functions to ordinary ones, e.g. `memcpy_s` -> `memcpy`
- `PRINT_XXX` -> `eapp_print`
- Comment out all `OsHookCall`

Other header files are also fully copied (except for `task.h`), but not the corresponding `.c` files.
